### PR TITLE
Updates for pip package to work as command line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from monailabel import __version__
 
 with open('README.md') as f:
     readme = f.read()
@@ -6,14 +7,24 @@ with open('README.md') as f:
 with open('LICENSE') as f:
     license_desc = f.read()
 
+with open('requirements.txt') as f:
+    requirements = [l.strip() for l in f]
+
 setup(
     name='monai-label',
-    version='1.0.0',
-    description='MONAI Label',
+    version=__version__,
+    description='MONAI Label Development Kit',
     long_description=readme,
-    author='MONAI Label',
-    author_email='label@monai.com',
-    url='http://monai.com',
+    url='http://monai.io',
     license=license_desc,
-    packages=find_packages(exclude=('tests', 'docs', 'apps'))
+    packages=find_packages(exclude=('tests', 'docs', 'apps')),
+    python_requires='>=3.6',
+    install_requires=requirements,
+    entry_points={
+        'console_scripts': [
+            'monai-label = monailabel.main:run_main',
+        ]
+    },
+    include_package_data=True,
+    data_files=[('logconfig',['monailabel/logging.json'])],
 )


### PR DESCRIPTION
After installation
```
pip install .
```
one can run
```
monai-label --app apps/my_app --studies /raid/datasets/Task09_Spleen --port 8081
```