### PR TITLE
Adding custom tag support and managing labels from within labels subdirectory

### DIFF
--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 
 import yaml
 
-from monailabel.interfaces.datastore import Datastore, LabelTag
+from monailabel.interfaces.datastore import Datastore, DefaultLabelTag
 from monailabel.interfaces.exception import MONAILabelError, MONAILabelException
 from monailabel.utils.activelearning import Random
 from monailabel.utils.datastore import LocalDatastore
@@ -75,6 +75,7 @@ class MONAILabelApp:
                         "model": "segmentation_spleen",
                         "image": "file://xyz",
                         "save_label": "true/false",
+                        "label_tag": "my_custom_label_tag", (if not provided defaults to `original`)
                         "params": {},
                     }
 
@@ -99,7 +100,11 @@ class MONAILabelApp:
         result_file_name, result_json = task(request)
 
         if request.get("save_label", True):
-            self.datastore().save_label(image_id, result_file_name, LabelTag.ORIGINAL)
+            self.datastore().save_label(
+                image_id,
+                result_file_name,
+                request.get("label_tag") if request.get("label_tag") else DefaultLabelTag.ORIGINAL.value,
+            )
 
         return {"label": result_file_name, "params": result_json}
 
@@ -175,6 +180,7 @@ class MONAILabelApp:
                         "image": "file://xyz.com",
                         "label": "file://label_xyz.com",
                         "segments" ["spleen"],
+                        "label_tag": "my_custom_label_tag", (if not provided defaults to `final`)
                         "params": {},
                     }
 
@@ -182,7 +188,11 @@ class MONAILabelApp:
             JSON containing next image and label info
         """
 
-        label_id = self.datastore().save_label(request["image"], request["label"], LabelTag.FINAL)
+        label_id = self.datastore().save_label(
+            request["image"],
+            request["label"],
+            request.get("label_tag") if request.get("label_tag") else DefaultLabelTag.FINAL.value,
+        )
 
         return {
             "image": request.get("image"),

--- a/monailabel/interfaces/datastore.py
+++ b/monailabel/interfaces/datastore.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, List
 
 
-class LabelTag(Enum):
+class DefaultLabelTag(Enum):
     ORIGINAL = "original"
     FINAL = "final"
 
@@ -52,14 +52,15 @@ class Datastore(metaclass=ABCMeta):
     @abstractmethod
     def datalist(self) -> List[Dict[str, str]]:
         """
-        Return a dictionary of (image, label) pairs corresponding to the ('image', 'label) keys respectively
+        Return a dictionary of image and label pairs corresponding to the 'image' and 'label'
+        keys respectively
 
         :return: the {'label': image, 'label': label} pairs for training
         """
         pass
 
     @abstractmethod
-    def get_labels_by_image_id(self, image_id: str) -> Dict[str, LabelTag]:
+    def get_labels_by_image_id(self, image_id: str) -> Dict[str, str]:
         """
         Retrieve all label ids for the given image id
 
@@ -156,13 +157,13 @@ class Datastore(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def save_label(self, image_id: str, label_filename: str, label_tag: LabelTag) -> str:
+    def save_label(self, image_id: str, label_filename: str, label_tag: str) -> str:
         """
         Save a label for the given image id and return the newly saved label's id
 
         :param image_id: the image id for the label
         :param label_filename: the path to the label file
-        :param label_tag: the tag for the label
+        :param label_tag: the user-provided tag for the label
         :return: the label id for the given label filename
         """
         pass

--- a/monailabel/utils/datastore/local.py
+++ b/monailabel/utils/datastore/local.py
@@ -3,12 +3,11 @@ import json
 import os
 import pathlib
 import shutil
-from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from pydantic import BaseModel
 
-from monailabel.interfaces.datastore import Datastore, LabelTag
+from monailabel.interfaces.datastore import Datastore, DefaultLabelTag
 from monailabel.interfaces.exception import ImageNotFoundException, LabelNotFoundException
 
 
@@ -47,7 +46,13 @@ class LocalDatastore(Datastore):
         The description of the datastore
     """
 
-    def __init__(self, datastore_path: str, datastore_config: str = "datastore.json"):
+    def __init__(
+        self,
+        datastore_path: str,
+        datastore_config: str = "datastore.json",
+        label_store_path: str = "labels",
+        reconcile_datastore: bool = True,
+    ):
         """
         Creates a `LocalDataset` object
 
@@ -61,19 +66,23 @@ class LocalDatastore(Datastore):
         """
         self._datastore_path = datastore_path
         self._datastore_config_path = os.path.join(datastore_path, datastore_config)
+        self._label_store_path = label_store_path
 
-        # check if dataset configuration file exists
         if os.path.exists(self._datastore_config_path):
+            # check if dataset configuration file exists and load if it does
             self._datastore = LocalDatastoreModel.parse_file(self._datastore_config_path)
         else:
+            # otherwise create anew
             self._datastore = LocalDatastoreModel(name="new-dataset", description="New Dataset")
 
-            files = LocalDatastore._list_files(datastore_path)
+        # ensure labels path exists regardless of whether a datastore file is present
+        os.makedirs(os.path.join(self._datastore_path, self._label_store_path), exist_ok=True)
 
-            for file in files:
-                self._datastore.objects.append(ObjectModel(image=ImageModel(id=file)))
+        # reconcile the loaded datastore file with any existing files in the path
+        if reconcile_datastore:
+            self._reconcile_datastore()
 
-            self._update_datastore_file()
+        self._update_datastore_file()
 
     @property
     def name(self) -> str:
@@ -115,23 +124,41 @@ class LocalDatastore(Datastore):
         self._datastore.description = description
         self._update_datastore_file()
 
-    def datalist(self, full_path=True) -> List[Dict[str, str]]:
+    @property
+    def datastore_path(self):
+        return self._datastore_path
 
+    @property
+    def labelstore_path(self):
+        return os.path.join(self._datastore_path, self._label_store_path)
+
+    def datalist(self, full_path=True) -> List[Dict[str, str]]:
+        """
+        Return a dictionary of image and label pairs corresponding to the 'image' and 'label'
+        keys respectively
+
+        :return: the {'label': image, 'label': label} pairs for training
+        """
         items = []
         for obj in self._datastore.objects:
-            image_path = self._get_path(obj.image.id, full_path)
+            image_path = self._get_path(obj.image.id, False, full_path)
             for label in obj.labels:
-                if label.tag == LabelTag.FINAL.value:
+                if label.tag == DefaultLabelTag.FINAL.value:
                     items.append(
                         {
                             "image": image_path,
-                            "label": self._get_path(label.id, full_path),
+                            "label": self._get_path(label.id, True, full_path),
                         }
                     )
         return items
 
     def get_image(self, image_id: str) -> io.BytesIO:
+        """
+        Retrieve image object based on image id
 
+        :param image_id: the desired image's id
+        :return: return the "image"
+        """
         buf = None
         for obj in self._datastore.objects:
             if obj.image.id == image_id:
@@ -141,7 +168,12 @@ class LocalDatastore(Datastore):
         return buf
 
     def get_image_uri(self, image_id: str) -> str:
+        """
+        Retrieve image uri based on image id
 
+        :param image_id: the desired image's id
+        :return: return the image uri
+        """
         image_path = None
         for obj in self._datastore.objects:
             if obj.image.id == image_id:
@@ -150,7 +182,12 @@ class LocalDatastore(Datastore):
         return image_path
 
     def get_image_info(self, image_id: str) -> Dict[str, Any]:
+        """
+        Get the image information for the given image id
 
+        :param image_id: the desired image id
+        :return: image info as a list of dictionaries Dict[str, Any]
+        """
         for obj in self._datastore.objects:
             if obj.image.id == image_id:
                 return obj.image.info
@@ -158,25 +195,40 @@ class LocalDatastore(Datastore):
         return {}
 
     def get_label(self, label_id: str) -> io.BytesIO:
+        """
+        Retrieve image object based on label id
 
+        :param label_id: the desired label's id
+        :return: return the "label"
+        """
         buf = None
         for obj in self._datastore.objects:
             for label in obj.labels:
                 if label.id == label_id:
-                    with open(os.path.join(self._datastore_path, label.id)) as f:
+                    with open(os.path.join(self._datastore_path, self._label_store_path, label.id)) as f:
                         buf = io.BytesIO(f.read())
         return buf
 
     def get_label_uri(self, label_id: str) -> str:
+        """
+        Retrieve label uri based on image id
 
+        :param label_id: the desired label's id
+        :return: return the label uri
+        """
         for obj in self._datastore.objects:
             for label in obj.labels:
                 if label.id == label_id:
-                    return os.path.join(self._datastore_path, label.id)
+                    return os.path.join(self._datastore_path, self._label_store_path, label.id)
         return None
 
-    def get_labels_by_image_id(self, image_id: str) -> LabelModel:
+    def get_labels_by_image_id(self, image_id: str) -> Dict[str, str]:
+        """
+        Retrieve all label ids for the given image id
 
+        :param image_id: the desired image's id
+        :return: label ids mapped to the appropriate tag as Dict[str, str]
+        """
         for obj in self._datastore.objects:
             if obj.image.id == image_id:
                 labels = {label.id: label.tag for label in obj.labels}
@@ -184,7 +236,12 @@ class LocalDatastore(Datastore):
         return {}
 
     def get_label_info(self, label_id: str) -> Dict[str, Any]:
+        """
+        Get the label information for the given label id
 
+        :param label_id: the desired label id
+        :return: label info as a list of dictionaries Dict[str, Any]
+        """
         for obj in self._datastore.objects:
             for label in obj.labels:
                 if label.id == label_id:
@@ -193,52 +250,71 @@ class LocalDatastore(Datastore):
         return {}
 
     def get_labeled_images(self) -> List[str]:
+        """
+        Get all images that have a corresponding label
 
+        :return: list of image ids List[str]
+        """
         image_ids = []
         for obj in self._datastore.objects:
             for label in obj.labels:
-                if label.tag == LabelTag.FINAL.value:
+                if label.tag == DefaultLabelTag.FINAL.value:
                     image_ids.append(obj.image.id)
 
         return image_ids
 
     def get_unlabeled_images(self) -> List[str]:
+        """
+        Get all images that have no corresponding label
 
+        :return: list of image ids List[str]
+        """
         image_ids = []
         for obj in self._datastore.objects:
-            if not obj.labels or LabelTag.FINAL.value not in [label.tag for label in obj.labels]:
+            if not obj.labels or DefaultLabelTag.FINAL.value not in [label.tag for label in obj.labels]:
                 image_ids.append(obj.image.id)
 
         return image_ids
 
     def list_images(self) -> List[str]:
+        """
+        Return list of image ids available in the datastore
 
+        :return: list of image ids List[str]
+        """
         return [obj.image.id for obj in self._datastore.objects]
 
-    def save_label(self, image_id: str, label_filename: str, label_tag: LabelTag) -> str:
+    def save_label(self, image_id: str, label_filename: str, label_tag: str) -> str:
+        """
+        Save a label for the given image id and return the newly saved label's id
 
+        :param image_id: the image id for the label
+        :param label_filename: the path to the label file
+        :param label_tag: the tag for the label
+        :return: the label id for the given label filename
+        """
         for obj in self._datastore.objects:
 
             if obj.image.id == image_id:
 
                 image_ext = "".join(pathlib.Path(image_id).suffixes)
                 label_ext = "".join(pathlib.Path(label_filename).suffixes)
-                label_id = "label_" + label_tag.value + "_" + image_id.replace(image_ext, "") + label_ext
+                label_id = "label_" + label_tag + "_" + image_id.replace(image_ext, "") + label_ext
 
-                datastore_label_path = os.path.join(self._datastore_path, label_id)
+                datastore_label_path = os.path.join(self._datastore_path, self._label_store_path, label_id)
                 shutil.copy(src=label_filename, dst=datastore_label_path, follow_symlinks=True)
 
-                if label_tag.value not in [label.tag for label in obj.labels]:
+                if label_tag not in [label.tag for label in obj.labels]:
                     obj.labels.append(
                         LabelModel(
                             id=label_id,
-                            tag=label_tag.value,
+                            tag=label_tag,
                         )
                     )
                 else:
                     for label_index, label in enumerate(obj.labels):
-                        if label.tag == label_tag.value:
-                            obj.labels[label_index] = LabelModel(id=label_id, tag=label_tag.value)
+                        if label.tag == label_tag:
+                            obj.labels[label_index] = LabelModel(id=label_id, tag=label_tag)
 
                 self._update_datastore_file()
 
@@ -248,23 +324,44 @@ class LocalDatastore(Datastore):
             raise ImageNotFoundException(f"Image {image_id} not found")
 
     def update_image_info(self, image_id: str, info: Dict[str, Any]) -> None:
+        """
+        Update (or create a new) info tag for the desired image
 
-        for obj_index, obj in enumerate(self._datastore.objects):
+        :param image_id: the id of the image we want to add/update info
+        :param info: a dictionary of custom image information Dict[str, Any]
+        """
+        for obj in self._datastore.objects:
             if obj.image.id == image_id:
-                self._datastore.objects[obj_index].image.info.update(info)
+                obj.image.info.update(info)
+                self._update_datastore_file()
                 break
         else:
             raise ImageNotFoundException(f"Image {image_id} not found")
 
     def update_label_info(self, label_id: str, info: Dict[str, Any]) -> None:
+        """
+        Update (or create a new) info tag for the desired label
 
-        for obj_index, obj in enumerate(self._datastore.objects):
-            for label_index, label in enumerate(obj.labels):
+        :param label_id: the id of the label we want to add/update info
+        :param info: a dictionary of custom label information Dict[str, Any]
+        """
+        for obj in self._datastore.objects:
+            for label in obj.labels:
                 if label.id == label_id:
-                    self._datastore.objects[obj_index].labels[label_index].info.update(info)
-                    return
+                    label.info.update(info)
+                    self._update_datastore_file()
+                return
 
         raise LabelNotFoundException(f"Label {label_id} not found")
+
+    def _get_path(self, path: str, is_label: bool, full_path=True):
+        if is_label:
+            path = os.path.join(self._label_store_path, path)
+
+        if not full_path or os.path.isabs(path):
+            return path
+
+        return os.path.realpath(os.path.join(self._datastore_path, path))
 
     @staticmethod
     def _list_files(path: str):
@@ -274,11 +371,58 @@ class LocalDatastore(Datastore):
             relative_file_paths.extend([os.path.join(base_dir, file) for file in files])
         return relative_file_paths
 
+    def _reconcile_datastore(self):
+        self._remove_object_with_missing_file()
+        self._add_object_with_present_file()
+
+    def _remove_object_with_missing_file(self) -> None:
+        """
+        remove objects present in the datastore file but not present on path
+        (even if labels exist, if images do not the whole object is removed from the datastore)
+        """
+        files = LocalDatastore._list_files(self._datastore_path)
+        image_id_files = [file for file in files if not file.startswith(self._label_store_path)]
+        image_id_datastore = [obj.image.id for obj in self._datastore.objects]
+        missing_file_image_id = list(set(image_id_datastore) - set(image_id_files))
+
+        obj_idx = 0
+        deleted_items = 0
+        while len(missing_file_image_id) > deleted_items:
+            if self._datastore.objects[obj_idx].image.id in missing_file_image_id:
+                del self._datastore.objects[obj_idx]
+                deleted_items += 1
+            else:
+                obj_idx += 1
+
+    def _add_object_with_present_file(self) -> None:
+        """
+        add objects which are not present in the datastore file, but are present in the datastore directory
+        this adds the image present in the datastore path and any corresponding labels for that image
+        """
+        files = LocalDatastore._list_files(self._datastore_path)
+        image_id_files = [file for file in files if not file.startswith(self._label_store_path)]
+
+        for image_id in image_id_files:
+            if (
+                image_id not in [obj.image.id for obj in self._datastore.objects]
+                and image_id != pathlib.Path(self._datastore_config_path).name
+            ):
+                self._datastore.objects.append(ObjectModel(image=ImageModel(id=image_id)))
+
+                image_ext = "".join(pathlib.Path(image_id).suffixes)
+                image_id_nosuffix = image_id.replace(image_ext, "")
+
+                # find label files related to the image id being added to the datastore
+                label_id_files = [
+                    pathlib.Path(file).name
+                    for file in files
+                    if file.startswith(self._label_store_path) and "label_" in file and image_id_nosuffix in file
+                ]
+                for label_id in label_id_files:
+                    label_parts = label_id.split(image_id_nosuffix)
+                    label_tag = label_parts[0].replace("label_", "")
+                    self._datastore.objects[-1].labels.append(LabelModel(id=label_id, tag=label_tag))
+
     def _update_datastore_file(self):
         with open(self._datastore_config_path, "w") as f:
             json.dump(self._datastore.dict(), f, indent=2, default=str)
-
-    def _get_path(self, path: str, full_path=True):
-        if not full_path or os.path.isabs(path):
-            return path
-        return os.path.realpath(os.path.join(self._datastore_path, path))

--- a/monailabel/utils/datastore/local.py
+++ b/monailabel/utils/datastore/local.py
@@ -384,15 +384,13 @@ class LocalDatastore(Datastore):
         image_id_files = [file for file in files if not file.startswith(self._label_store_path)]
         image_id_datastore = [obj.image.id for obj in self._datastore.objects]
         missing_file_image_id = list(set(image_id_datastore) - set(image_id_files))
+        self._datastore.objects = [obj for obj in self._datastore.objects if obj.image.id not in missing_file_image_id]
 
-        obj_idx = 0
-        deleted_items = 0
-        while len(missing_file_image_id) > deleted_items:
-            if self._datastore.objects[obj_idx].image.id in missing_file_image_id:
-                del self._datastore.objects[obj_idx]
-                deleted_items += 1
-            else:
-                obj_idx += 1
+        label_id_files = [file for file in files if file.startswith(self._label_store_path)]
+        label_id_datastore = [obj.labels for obj in self._datastore.objects]
+        missing_file_label_id = list(set(label_id_datastore) - set(label_id_files))
+        for obj in self._datastore.objects:
+            obj.labels = [label for label in obj.labels if label.id not in missing_file_label_id]
 
     def _add_object_with_present_file(self) -> None:
         """

--- a/monailabel/utils/datastore/local.py
+++ b/monailabel/utils/datastore/local.py
@@ -421,9 +421,11 @@ class LocalDatastore(Datastore):
                 if file.startswith(self._label_store_path) and "label_" in file and image_id_nosuffix in file
             ]
             for label_id in label_id_files:
+                image_id_index = [obj.image.id for obj in self._datastore.objects].index(image_id)
                 label_parts = label_id.split(image_id_nosuffix)
-                label_tag = label_parts[0].replace("label_", "")
-                self._datastore.objects[-1].labels.append(LabelModel(id=label_id, tag=label_tag))
+                label_tag = label_parts[0].replace("label_", "").strip("_")
+                if label_id not in [label.id for label in self._datastore.objects[image_id_index].labels]:
+                    self._datastore.objects[image_id_index].labels.append(LabelModel(id=label_id, tag=label_tag))
 
     def _update_datastore_file(self):
         with open(self._datastore_config_path, "w") as f:


### PR DESCRIPTION
Address issue #72

- added ability to add custom label tags
- local datastore stores labels inside `labels` subdirectory