### PR TITLE
Add run-time settings through env while running app

### DIFF
--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -1,25 +1,24 @@
-from typing import List, Union
+from typing import List
 
-from pydantic import AnyHttpUrl, BaseSettings, validator
+from pydantic import AnyHttpUrl, BaseSettings
 
 
 class Settings(BaseSettings):
     API_STR: str = ""
-    BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
     PROJECT_NAME: str = "MONAILabel"
 
     APP_DIR: str = ""
     STUDIES: str = ""
+    APP_PORT: int = 8000
 
-    @validator("BACKEND_CORS_ORIGINS", pre=True)
-    def assemble_cors_origins(cls, v: Union[str, List[str]]) -> Union[List[str], str]:
-        if isinstance(v, str) and not v.startswith("["):
-            return [i.strip() for i in v.split(",")]
-        elif isinstance(v, (list, str)):
-            return v
-        raise ValueError(v)
+    DATASTORE_AUTO_RELOAD: bool = True
+    DATASTORE_IMAGE_EXT: List[str] = ["*.nii.gz", "*.nii"]
+    DATASTORE_LABEL_EXT: List[str] = ["*.nii.gz", "*.nii"]
+
+    BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
 
     class Config:
+        env_file = ".env"
         case_sensitive = True
 
 

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -45,7 +45,7 @@ class MONAILabelApp:
             studies,
             image_extensions=settings.DATASTORE_IMAGE_EXT,
             label_extensions=settings.DATASTORE_LABEL_EXT,
-            auto_reload=settings.DATASTORE_AUTO_RELOAD
+            auto_reload=settings.DATASTORE_AUTO_RELOAD,
         )
         self._download(resources)
 

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 import yaml
 from monai.apps import download_url
 
+from monailabel.config import settings
 from monailabel.interfaces.datastore import Datastore, DefaultLabelTag
 from monailabel.interfaces.exception import MONAILabelError, MONAILabelException
 from monailabel.utils.activelearning import Random
@@ -40,7 +41,12 @@ class MONAILabelApp:
         self.infers = dict() if infers is None else infers
         self.strategies = {"random", Random()} if strategies is None else strategies
 
-        self._datastore: Datastore = LocalDatastore(studies)
+        self._datastore: Datastore = LocalDatastore(
+            studies,
+            image_extensions=settings.DATASTORE_IMAGE_EXT,
+            label_extensions=settings.DATASTORE_LABEL_EXT,
+            auto_reload=settings.DATASTORE_AUTO_RELOAD
+        )
         self._download(resources)
 
     def info(self):
@@ -220,7 +226,7 @@ class MONAILabelApp:
 
     def add_deepgrow_infer_tasks(self):
         deepgrow_2d = os.path.join(self.app_dir, "model", "deepgrow_2d.ts")
-        deepgrow_3d = os.path.join(self.model_dir, "model", "deepgrow_3d.ts")
+        deepgrow_3d = os.path.join(self.app_dir, "model", "deepgrow_3d.ts")
 
         self.infers.update(
             {

--- a/monailabel/utils/datastore/local.py
+++ b/monailabel/utils/datastore/local.py
@@ -79,6 +79,10 @@ class LocalDatastore(Datastore):
         self._image_extensions = [image_extensions] if isinstance(image_extensions, str) else image_extensions
         self._label_extensions = [label_extensions] if isinstance(label_extensions, str) else label_extensions
 
+        logger.info(f"Image Extensions: {self._image_extensions}")
+        logger.info(f"Label Extensions: {self._label_extensions}")
+        logger.info(f"Auto Reload: {auto_reload}")
+
         if os.path.exists(self._datastore_config_path):
             # check if dataset configuration file exists and load if it does
             self._datastore = LocalDatastoreModel.parse_file(self._datastore_config_path)
@@ -94,6 +98,7 @@ class LocalDatastore(Datastore):
         self._update_datastore_file()
 
         if auto_reload:
+            logger.info("Start observing external modifications on datastore (AUTO RELOAD)")
             include_patterns = [
                 f"{self._datastore_path}{os.path.sep}{ext}" for ext in [*image_extensions, *label_extensions]
             ]
@@ -309,9 +314,10 @@ class LocalDatastore(Datastore):
         return [obj.image.id for obj in self._datastore.objects]
 
     def _on_any_event(self, event):
+        logger.debug(f"Event: {event}")
         self.refresh()
 
-    def refresh(self, event=None):
+    def refresh(self):
         """
         Refresh the datastore based on the state of the files on disk
         """

--- a/monailabel/utils/datastore/local.py
+++ b/monailabel/utils/datastore/local.py
@@ -341,6 +341,7 @@ class LocalDatastore(Datastore):
                 label_ext = "".join(pathlib.Path(label_filename).suffixes)
                 label_id = "label_" + label_tag + "_" + image_id.replace(image_ext, "") + label_ext
 
+                os.makedirs(os.path.join(self._datastore_path, self._label_store_path), exist_ok=True)
                 datastore_label_path = os.path.join(self._datastore_path, self._label_store_path, label_id)
                 shutil.copy(src=label_filename, dst=datastore_label_path, follow_symlinks=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests-toolbelt==0.9.1
 uvicorn==0.13.4
 watchdog==2.0.2
 pydantic==1.8.2
+python-dotenv==0.17.1


### PR DESCRIPTION
save current configs in .env file thorugh 
`python main.py -a ..\sample-apps\deepedit_heart -s C:\Datasets\Task02_Heart\imagesTr --dryrun`

Or you can set/override anything .env or through command line

Windows: 
```
set DATASTORE_AUTO_RELOAD=True
python main.py -a ..\sample-apps\deepedit_heart -s C:\Datasets\Task02_Heart\imagesTr
```

Ubuntu::
`DATASTORE_IMAGE_EXT='["*.nii.gz"]' python main.py -a ../sample-apps/deepgrow/ -s /workspace/Datasets/Task09_Spleen/imagesTr/`

When you run the app it will list all the possible settings for user:
```
**********************************************************
                  ENV VARIABLES/SETTINGS
**********************************************************
set API_STR=
set PROJECT_NAME=MONAILabel
set APP_DIR=C:\Projects\MONAILabel\sample-apps\deepedit_heart
set STUDIES=C:\Datasets\Task02_Heart\imagesTr
set APP_PORT=8000
set DATASTORE_AUTO_RELOAD=True
set DATASTORE_IMAGE_EXT=["*.nii.gz", "*.nii"]
set DATASTORE_LABEL_EXT=["*.nii.gz", "*.nii"]
set BACKEND_CORS_ORIGINS=[]
**********************************************************
```