### PR TITLE
Flatten 2D based on config + add train/val batch size config

### DIFF
--- a/monailabel/interfaces/tasks/train.py
+++ b/monailabel/interfaces/tasks/train.py
@@ -233,13 +233,18 @@ class TrainTask:
         stats: Dict[str, Any] = dict()
         stats.update(self._trainer.get_train_stats())
         stats["epoch"] = self._trainer.state.epoch
-        stats["total_time"] = str(datetime.timedelta(seconds=int(time.time() - self._start_time)))
-        stats["best_metric"] = self._trainer.state.best_metric
+        stats["start_ts"] = int(self._start_time)
+
+        if self._trainer.state.epoch == self._trainer.state.max_epochs:
+            stats["total_time"] = str(datetime.timedelta(seconds=int(time.time() - self._start_time)))
+        else:
+            stats["current_time"] = str(datetime.timedelta(seconds=int(time.time() - self._start_time)))
 
         for k, v in {"train": self._trainer, "eval": self._evaluator}.items():
             if not v:
                 continue
 
+            stats["best_metric"] = v.state.best_metric
             stats[k] = {
                 "metrics": TrainTask.tensor_to_list(v.state.metrics),
                 # "metric_details": tensor_to_list(v.state.metric_details),

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -26,7 +26,7 @@
    <item>
     <layout class="QGridLayout" name="serverSettings">
      <item row="0" column="2">
-      <widget class="QPushButton" name="fetchModelsButton">
+      <widget class="QPushButton" name="fetchServerInfoButton">
        <property name="enabled">
         <bool>true</bool>
        </property>
@@ -222,7 +222,7 @@
       <item row="9" column="0" colspan="2">
        <widget class="QProgressBar" name="accuracyProgressBar">
         <property name="toolTip">
-         <string>Average Dice score computed over submitted labels</string>
+         <string>Current Model Accuracy</string>
         </property>
         <property name="value">
          <number>0</number>

--- a/sample-apps/deepedit_brain_tumor/info.yaml
+++ b/sample-apps/deepedit_brain_tumor/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/deepedit_brain_tumor/main.py
+++ b/sample-apps/deepedit_brain_tumor/main.py
@@ -99,6 +99,8 @@ class MyApp(MONAILabelApp):
             lr=request.get("lr", 0.0001),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 

--- a/sample-apps/deepedit_left_atrium/info.yaml
+++ b/sample-apps/deepedit_left_atrium/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/deepedit_left_atrium/main.py
+++ b/sample-apps/deepedit_left_atrium/main.py
@@ -99,6 +99,8 @@ class MyApp(MONAILabelApp):
             lr=request.get("lr", 0.0001),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 

--- a/sample-apps/deepedit_lung/info.yaml
+++ b/sample-apps/deepedit_lung/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/deepedit_lung/main.py
+++ b/sample-apps/deepedit_lung/main.py
@@ -99,6 +99,8 @@ class MyApp(MONAILabelApp):
             lr=request.get("lr", 0.0001),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 

--- a/sample-apps/deepedit_spleen/info.yaml
+++ b/sample-apps/deepedit_spleen/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/deepedit_spleen/main.py
+++ b/sample-apps/deepedit_spleen/main.py
@@ -99,6 +99,8 @@ class MyApp(MONAILabelApp):
             lr=request.get("lr", 0.0001),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 

--- a/sample-apps/deepgrow_left_atrium/info.yaml
+++ b/sample-apps/deepgrow_left_atrium/info.yaml
@@ -19,3 +19,10 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1
+    2d_train_random_slices: 10
+    2d_val_random_slices: 5
+    2d_epochs: 20
+    2d_train_batch_size: 16
+    2d_val_batch_size: 16

--- a/sample-apps/deepgrow_left_atrium/main.py
+++ b/sample-apps/deepgrow_left_atrium/main.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -122,9 +123,20 @@ class MyApp(MONAILabelApp):
                     lr=request.get("lr", 0.0001),
                     max_epochs=request.get("epochs", 1),
                     amp=request.get("amp", True),
+                    train_batch_size=request.get("train_batch_size", 1),
+                    val_batch_size=request.get("val_batch_size", 1),
                 )
             elif model == "deepgrow_2d":
-                # TODO:: Flatten the dataset and batch it instead of picking random slice id
+                flatten_train_d = []
+                for _ in range(max(request.get("2d_train_random_slices", 20), 1)):
+                    flatten_train_d.extend(copy.deepcopy(train_d))
+                logger.info(f"After flatten:: {len(train_d)} => {len(flatten_train_d)}")
+
+                flatten_val_d = []
+                for _ in range(max(request.get("2d_val_random_slices", 5), 1)):
+                    flatten_val_d.extend(copy.deepcopy(val_d))
+                logger.info(f"After flatten:: {len(val_d)} => {len(flatten_val_d)}")
+
                 task = TrainDeepgrow(
                     dimension=2,
                     roi_size=(256, 256),
@@ -132,16 +144,18 @@ class MyApp(MONAILabelApp):
                     max_train_interactions=15,
                     max_val_interactions=5,
                     output_dir=output_dir,
-                    train_datalist=train_d,
-                    val_datalist=val_d,
+                    train_datalist=flatten_train_d,
+                    val_datalist=flatten_val_d,
                     network=network,
                     load_path=load_path,
                     publish_path=final_model,
                     stats_path=train_stats_path,
                     device=request.get("device", "cuda"),
                     lr=request.get("lr", 0.0001),
-                    max_epochs=request.get("epochs", 1),
+                    max_epochs=request.get("2d_epochs", 1),
                     amp=request.get("amp", True),
+                    train_batch_size=request.get("2d_train_batch_size", 4),
+                    val_batch_size=request.get("2d_val_batch_size", 4),
                 )
             else:
                 raise Exception(f"Train Definition for {model} Not Found")
@@ -155,15 +169,21 @@ class MyApp(MONAILabelApp):
         return result
 
     def train_stats(self):
-        # Return 3D stats as main stats and add 2D starts as part of
+        # Return both 2D and 3D stats.  Set current running or deepgrow_3d stats as active
         res = {}
+        active = {}
+        start_ts = 0
         for model in ["deepgrow_3d", "deepgrow_2d"]:
             train_stats_path = os.path.join(self.model_dir, f"train_stats_{model}.json")
             if os.path.exists(train_stats_path):
                 with open(train_stats_path, "r") as fc:
-                    if res:
-                        res[model] = json.load(fc)
-                    else:
-                        res = json.load(fc)
+                    r = json.load(fc)
+                    res[model] = r
 
-        return res
+                    # Set current running or last ran model as active
+                    if not active or r.get("current_time") or r.get("start_ts", 0) > start_ts:
+                        start_ts = r.get("start_ts", 0)
+                        active = copy.deepcopy(r)
+
+        active.update(res)
+        return active

--- a/sample-apps/deepgrow_spleen/info.yaml
+++ b/sample-apps/deepgrow_spleen/info.yaml
@@ -19,3 +19,10 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1
+    2d_train_random_slices: 10
+    2d_val_random_slices: 5
+    2d_epochs: 20
+    2d_train_batch_size: 16
+    2d_val_batch_size: 16

--- a/sample-apps/deepgrow_spleen/main.py
+++ b/sample-apps/deepgrow_spleen/main.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -122,9 +123,20 @@ class MyApp(MONAILabelApp):
                     lr=request.get("lr", 0.0001),
                     max_epochs=request.get("epochs", 1),
                     amp=request.get("amp", True),
+                    train_batch_size=request.get("train_batch_size", 1),
+                    val_batch_size=request.get("val_batch_size", 1),
                 )
             elif model == "deepgrow_2d":
-                # TODO:: Flatten the dataset and batch it instead of picking random slice id
+                flatten_train_d = []
+                for _ in range(max(request.get("2d_train_random_slices", 20), 1)):
+                    flatten_train_d.extend(copy.deepcopy(train_d))
+                logger.info(f"After flatten:: {len(train_d)} => {len(flatten_train_d)}")
+
+                flatten_val_d = []
+                for _ in range(max(request.get("2d_val_random_slices", 5), 1)):
+                    flatten_val_d.extend(copy.deepcopy(val_d))
+                logger.info(f"After flatten:: {len(val_d)} => {len(flatten_val_d)}")
+
                 task = TrainDeepgrow(
                     dimension=2,
                     roi_size=(256, 256),
@@ -132,16 +144,18 @@ class MyApp(MONAILabelApp):
                     max_train_interactions=15,
                     max_val_interactions=5,
                     output_dir=output_dir,
-                    train_datalist=train_d,
-                    val_datalist=val_d,
+                    train_datalist=flatten_train_d,
+                    val_datalist=flatten_val_d,
                     network=network,
                     load_path=load_path,
                     publish_path=final_model,
                     stats_path=train_stats_path,
                     device=request.get("device", "cuda"),
                     lr=request.get("lr", 0.0001),
-                    max_epochs=request.get("epochs", 1),
+                    max_epochs=request.get("2d_epochs", 1),
                     amp=request.get("amp", True),
+                    train_batch_size=request.get("2d_train_batch_size", 4),
+                    val_batch_size=request.get("2d_val_batch_size", 4),
                 )
             else:
                 raise Exception(f"Train Definition for {model} Not Found")
@@ -155,15 +169,21 @@ class MyApp(MONAILabelApp):
         return result
 
     def train_stats(self):
-        # Return 3D stats as main stats and add 2D starts as part of
+        # Return both 2D and 3D stats.  Set current running or deepgrow_3d stats as active
         res = {}
+        active = {}
+        start_ts = 0
         for model in ["deepgrow_3d", "deepgrow_2d"]:
             train_stats_path = os.path.join(self.model_dir, f"train_stats_{model}.json")
             if os.path.exists(train_stats_path):
                 with open(train_stats_path, "r") as fc:
-                    if res:
-                        res[model] = json.load(fc)
-                    else:
-                        res = json.load(fc)
+                    r = json.load(fc)
+                    res[model] = r
 
-        return res
+                    # Set current running or last ran model as active
+                    if not active or r.get("current_time") or r.get("start_ts", 0) > start_ts:
+                        start_ts = r.get("start_ts", 0)
+                        active = copy.deepcopy(r)
+
+        active.update(res)
+        return active

--- a/sample-apps/segmentation_left_atrium/info.yaml
+++ b/sample-apps/segmentation_left_atrium/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/segmentation_left_atrium/main.py
+++ b/sample-apps/segmentation_left_atrium/main.py
@@ -79,6 +79,8 @@ class MyApp(MONAILabelApp):
             val_split=request.get("val_split", 0.2),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 

--- a/sample-apps/segmentation_spleen/info.yaml
+++ b/sample-apps/segmentation_spleen/info.yaml
@@ -15,3 +15,5 @@ config:
     lr: 0.0001
     epochs: 50
     val_split: 0.2
+    train_batch_size: 1
+    val_batch_size: 1

--- a/sample-apps/segmentation_spleen/main.py
+++ b/sample-apps/segmentation_spleen/main.py
@@ -79,6 +79,8 @@ class MyApp(MONAILabelApp):
             val_split=request.get("val_split", 0.2),
             max_epochs=request.get("epochs", 1),
             amp=request.get("amp", True),
+            train_batch_size=request.get("train_batch_size", 1),
+            val_batch_size=request.get("val_batch_size", 1),
         )
         return task()
 


### PR DESCRIPTION
- Flattend 2D train/val datalist for deepgrow 2D apps
- Add train/val batch size config for all apps
- In Slicer, use current/total epoch from train stats instead of locating from train logs

Signed-off-by: Sachidanand Alle <salle@nvidia.com>