### PR TITLE
Add pretrained flag

### DIFF
--- a/sample-apps/deepedit_brain_tumor/info.yaml
+++ b/sample-apps/deepedit_brain_tumor/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/deepedit_brain_tumor/main.py
+++ b/sample-apps/deepedit_brain_tumor/main.py
@@ -82,7 +82,9 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_brain_tumor/main.py
+++ b/sample-apps/deepedit_brain_tumor/main.py
@@ -83,8 +83,13 @@ class MyApp(MONAILabelApp):
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_left_atrium/info.yaml
+++ b/sample-apps/deepedit_left_atrium/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/deepedit_left_atrium/main.py
+++ b/sample-apps/deepedit_left_atrium/main.py
@@ -82,7 +82,9 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_left_atrium/main.py
+++ b/sample-apps/deepedit_left_atrium/main.py
@@ -83,8 +83,13 @@ class MyApp(MONAILabelApp):
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_lung/info.yaml
+++ b/sample-apps/deepedit_lung/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/deepedit_lung/main.py
+++ b/sample-apps/deepedit_lung/main.py
@@ -82,7 +82,9 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_lung/main.py
+++ b/sample-apps/deepedit_lung/main.py
@@ -83,8 +83,13 @@ class MyApp(MONAILabelApp):
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_spleen/info.yaml
+++ b/sample-apps/deepedit_spleen/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/deepedit_spleen/main.py
+++ b/sample-apps/deepedit_spleen/main.py
@@ -82,7 +82,9 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/deepedit_spleen/main.py
+++ b/sample-apps/deepedit_spleen/main.py
@@ -83,8 +83,13 @@ class MyApp(MONAILabelApp):
         load_path = os.path.join(output_dir, "model.pt")
         load_path = load_path if os.path.exists(load_path) else self.final_model
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/segmentation_left_atrium/info.yaml
+++ b/sample-apps/segmentation_left_atrium/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/segmentation_left_atrium/main.py
+++ b/sample-apps/segmentation_left_atrium/main.py
@@ -61,7 +61,9 @@ class MyApp(MONAILabelApp):
 
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/segmentation_left_atrium/main.py
+++ b/sample-apps/segmentation_left_atrium/main.py
@@ -62,8 +62,13 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/segmentation_spleen/info.yaml
+++ b/sample-apps/segmentation_spleen/info.yaml
@@ -10,6 +10,7 @@ config:
     device: cuda
   train:
     name: model_01
+    pretrained: False
     device: cuda
     amp: true
     lr: 0.0001

--- a/sample-apps/segmentation_spleen/main.py
+++ b/sample-apps/segmentation_spleen/main.py
@@ -66,8 +66,13 @@ class MyApp(MONAILabelApp):
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
         # Use pretrained weights to start training?
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
-            if request.get("pretrained", True) else None
+        load_path = (
+            load_path
+            if os.path.exists(load_path)
+            else self.pretrained_model
+            if request.get("pretrained", True)
+            else None
+        )
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))

--- a/sample-apps/segmentation_spleen/main.py
+++ b/sample-apps/segmentation_spleen/main.py
@@ -65,7 +65,9 @@ class MyApp(MONAILabelApp):
 
         # App Owner can decide which checkpoint to load (from existing output folder or from base checkpoint)
         load_path = os.path.join(output_dir, "model.pt")
-        load_path = load_path if os.path.exists(load_path) else self.pretrained_model
+        # Use pretrained weights to start training?
+        load_path = load_path if os.path.exists(load_path) else self.pretrained_model \
+            if request.get("pretrained", True) else None
 
         # Datalist for train/validation
         train_d, val_d = self.partition_datalist(self.datastore().datalist(), request.get("val_split", 0.2))


### PR DESCRIPTION
Add the flag "pretrained" so users can do cold-start training without many changes. 

- How to manage error when a user tries to perform inference without cold-start training and without having a pretrained model activate (pretrained flag is False)
- Should we do the same for DeepGrow? @finalelement 


Signed-off-by: Andres Diaz-Pinto <diazandr3s@gmail.com>