### PR TITLE
disable next sample button when no more unlabled images exist

### DIFF
--- a/monailabel/endpoints/datastore.py
+++ b/monailabel/endpoints/datastore.py
@@ -7,7 +7,7 @@ import tempfile
 from enum import Enum
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTasks
 
@@ -112,6 +112,9 @@ async def save_label(
 async def download_image(image):
     instance: MONAILabelApp = get_app_instance()
     image = instance.datastore().get_image_uri(image)
+    if not os.path.isfile(image):
+        raise HTTPException(status_code=404, detail="Image NOT Found")
+
     return FileResponse(image, media_type=get_mime_type(image), filename=os.path.basename(image))
 
 
@@ -119,4 +122,7 @@ async def download_image(image):
 async def download_label(label):
     instance: MONAILabelApp = get_app_instance()
     label = instance.datastore().get_label_uri(label)
+    if not os.path.isfile(label):
+        raise HTTPException(status_code=404, detail="Label NOT Found")
+
     return FileResponse(label, media_type=get_mime_type(label), filename=os.path.basename(label))

--- a/monailabel/endpoints/datastore.py
+++ b/monailabel/endpoints/datastore.py
@@ -8,10 +8,11 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, File, UploadFile
+from fastapi.responses import FileResponse
 from starlette.background import BackgroundTasks
 
 from monailabel.interfaces import Datastore, DefaultLabelTag, MONAILabelApp
-from monailabel.utils.others.generic import get_app_instance, remove_file
+from monailabel.utils.others.generic import get_app_instance, get_mime_type, remove_file
 
 logger = logging.getLogger(__name__)
 train_tasks: List = []
@@ -105,3 +106,17 @@ async def save_label(
         }
     )
     return res
+
+
+@router.get("/image", summary="Download Image")
+async def download_image(image):
+    instance: MONAILabelApp = get_app_instance()
+    image = instance.datastore().get_image_uri(image)
+    return FileResponse(image, media_type=get_mime_type(image), filename=os.path.basename(image))
+
+
+@router.get("/label", summary="Download Label")
+async def download_label(label):
+    instance: MONAILabelApp = get_app_instance()
+    label = instance.datastore().get_label_uri(label)
+    return FileResponse(label, media_type=get_mime_type(label), filename=os.path.basename(label))

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -347,7 +347,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.strategyBox.setCurrentIndex(self.ui.strategyBox.findText(currentStrategy) if currentStrategy else 0)
 
         # Enable/Disable
-        self.ui.nextSampleButton.setEnabled(self.ui.strategyBox.count)
+        self.ui.nextSampleButton.setEnabled(self.ui.strategyBox.count > 0 and current < total)
 
         is_training_running = True if self.info and self.isTrainingRunning() else False
         self.ui.trainingButton.setEnabled(self.info and not is_training_running)

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -350,9 +350,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.nextSampleButton.setEnabled(self.ui.strategyBox.count > 0 and current < total)
 
         is_training_running = True if self.info and self.isTrainingRunning() else False
-        self.ui.trainingButton.setEnabled(self.info and not is_training_running)
+        self.ui.trainingButton.setEnabled(current > 0 and self.info and not is_training_running)
         self.ui.stopTrainingButton.setEnabled(is_training_running)
-        self.ui.trainingStatusButton.setEnabled(self.info)
         if is_training_running and self.timer is None:
             self.timer = qt.QTimer()
             self.timer.setInterval(5000)


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <salle@nvidia.com>

- Disable next sample when no new samples/images exist to annotate
- Disable train button when there are zero submitted labels (no image/labels to train)
- Endpoints in /datastore to fetch/download any existing image/label