### PR TITLE
Slicer Plugin - fix readme and ui label text for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ For **_prerequisites_**, other installation methods (using the default GitHub br
 
 ### 3D Slicer
 
-Download Preview Release from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
+Download **Preview Release** from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
+> **Uninstall** any existing 3D-Slicer version before using the latest preview release. 
 
 Refer [3D Slicer plugin](plugins/slicer) for other options to install and run MONAI Label plugin in 3D Slicer.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For **_prerequisites_**, other installation methods (using the default GitHub br
 Download **Preview Release** from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
 
 Refer [3D Slicer plugin](plugins/slicer) for other options to install and run MONAI Label plugin in 3D Slicer.
-> To avoid conflicts with older version, you may want to _uninstall_ any previously installed 3D Slicer package. 
+> To avoid accidentally using an older Slicer version, you may want to _uninstall_ any previously installed 3D Slicer package. 
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For **_prerequisites_**, other installation methods (using the default GitHub br
 Download **Preview Release** from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
 
 Refer [3D Slicer plugin](plugins/slicer) for other options to install and run MONAI Label plugin in 3D Slicer.
-> To avoid conflicts with older version, you might need to _uninstall_ any previously installed 3D Slicer package. 
+> To avoid conflicts with older version, you may want to _uninstall_ any previously installed 3D Slicer package. 
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ For **_prerequisites_**, other installation methods (using the default GitHub br
 ### 3D Slicer
 
 Download **Preview Release** from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
-> **Uninstall** any existing 3D-Slicer version before using the latest preview release. 
 
 Refer [3D Slicer plugin](plugins/slicer) for other options to install and run MONAI Label plugin in 3D Slicer.
+> To avoid conflicts with older version, you might need to _uninstall_ any previously installed 3D Slicer package. 
+
 
 ## Contributing
 For guidance on making a contribution to MONAI Label, see the [contributing guidelines](CONTRIBUTING.md).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -105,5 +105,5 @@ Refer `3D Slicer plugin <https://github.com/Project-MONAI/MONAILabel/tree/main/p
 
 .. note::
 
-    To avoid conflicts with older version, you might need to *uninstall* any previously installed 3D Slicer package.
+    To avoid conflicts with older version, you may want to *uninstall* any previously installed 3D Slicer package.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -105,5 +105,5 @@ Refer `3D Slicer plugin <https://github.com/Project-MONAI/MONAILabel/tree/main/p
 
 .. note::
 
-    **Uninstall** any existing 3D-Slicer version before using the latest preview release.
+    To avoid conflicts with older version, you might need to *uninstall* any previously installed 3D Slicer package.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -105,5 +105,5 @@ Refer `3D Slicer plugin <https://github.com/Project-MONAI/MONAILabel/tree/main/p
 
 .. note::
 
-    To avoid conflicts with older version, you may want to *uninstall* any previously installed 3D Slicer package.
+    To avoid accidentally using an older Slicer version, you may want to *uninstall* any previously installed 3D Slicer package.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -102,3 +102,8 @@ You can start server using *monailabel* CLI
 Download Preview Release from https://download.slicer.org/ and install MONAI Label plugin from Slicer Extension Manager.
 
 Refer `3D Slicer plugin <https://github.com/Project-MONAI/MONAILabel/tree/main/plugins/slicer>`_ for other options to install and run MONAI Label plugin in 3D Slicer.
+
+.. note::
+
+    **Uninstall** any existing 3D-Slicer version before using the latest preview release.
+

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>425</width>
-    <height>713</height>
+    <height>802</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -174,48 +174,17 @@
       <property name="rightMargin">
        <number>0</number>
       </property>
-      <item row="6" column="1">
-       <widget class="QPushButton" name="stopTrainingButton">
-        <property name="text">
-         <string>Stop Training</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0" colspan="2">
-       <widget class="QCommandLinkButton" name="trainingStatusButton">
-        <property name="text">
-         <string>Training Status</string>
-        </property>
-        <property name="description">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QPushButton" name="saveLabelButton">
-        <property name="text">
-         <string>Submit Label</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="0" colspan="2">
-       <widget class="QProgressBar" name="trainingProgressBar">
+      <item row="0" column="0" colspan="2">
+       <widget class="QProgressBar" name="activeLearningProgressBar">
         <property name="value">
          <number>0</number>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="label_7">
+      <item row="11" column="0" colspan="2">
+       <widget class="QLabel" name="label_11">
         <property name="text">
-         <string>Strategy:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QPushButton" name="nextSampleButton">
-        <property name="text">
-         <string>Next Sample</string>
+         <string>Train Accuracy:</string>
         </property>
        </widget>
       </item>
@@ -226,17 +195,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QProgressBar" name="activeLearningProgressBar">
-        <property name="value">
-         <number>0</number>
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Strategy:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QComboBox" name="strategyBox"/>
-      </item>
-      <item row="9" column="0" colspan="2">
+      <item row="12" column="0" colspan="2">
        <widget class="QProgressBar" name="accuracyProgressBar">
         <property name="toolTip">
          <string>Average Dice score computed over submitted labels</string>
@@ -246,10 +212,44 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
-       <widget class="QLabel" name="label_11">
+      <item row="4" column="1">
+       <widget class="QPushButton" name="saveLabelButton">
         <property name="text">
-         <string>Model Accuracy:</string>
+         <string>Submit Label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QPushButton" name="stopTrainingButton">
+        <property name="text">
+         <string>Stop Training</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QPushButton" name="nextSampleButton">
+        <property name="text">
+         <string>Next Sample</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QComboBox" name="strategyBox"/>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QCommandLinkButton" name="trainingStatusButton">
+        <property name="text">
+         <string>Training Status</string>
+        </property>
+        <property name="description">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QProgressBar" name="trainingProgressBar">
+        <property name="value">
+         <number>0</number>
         </property>
        </widget>
       </item>

--- a/plugins/slicer/README.md
+++ b/plugins/slicer/README.md
@@ -8,6 +8,7 @@ Pick one of the following options to install MONAILabel Plugin for 3D Slicer
 
 ### Install 3D Slicer Preview Version with in-built Plugin
 
+- **Uninstall** any existing 3D-Slicer version
 - Download and Install [3D Slicer](https://download.slicer.org/) **Preview version**
 - Go to **View** -> **Extension Manager** -> **Active Learning** -> **MONAI Label**
 - Install MONAI Label plugin

--- a/plugins/slicer/README.md
+++ b/plugins/slicer/README.md
@@ -8,7 +8,6 @@ Pick one of the following options to install MONAILabel Plugin for 3D Slicer
 
 ### Install 3D Slicer Preview Version with in-built Plugin
 
-- **Uninstall** any existing 3D-Slicer version
 - Download and Install [3D Slicer](https://download.slicer.org/) **Preview version**
 - Go to **View** -> **Extension Manager** -> **Active Learning** -> **MONAI Label**
 - Install MONAI Label plugin


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Based on feedback
- [x] Add a note to handle with any previous version for slicer
- [x] Rename name from Model Accuracy => Train Accuracy and move it under Training status
