### PR TITLE
Disable train button when no labels are available

### DIFF
--- a/monailabel/scripts/run_monailabel_app.bat
+++ b/monailabel/scripts/run_monailabel_app.bat
@@ -8,7 +8,7 @@ set request=%4
 set COUNT=
 
 echo Virtual Env: %VIRTUAL_ENV%
-if exist %app_dir%\requirements.txt (
+if exist %app_dir%\requirements.txt.invalid (
     for /f "tokens=*" %%i in ('findstr /v "#" %app_dir%\requirements.txt ^| findstr "." ^| find /c /v ""') do (
         set COUNT=%%i
         goto :done

--- a/monailabel/scripts/run_monailabel_app.sh
+++ b/monailabel/scripts/run_monailabel_app.sh
@@ -22,7 +22,7 @@ fi
 
 echo "USING PYTHON: $(which ${PYEXE})"
 
-if test -f "${app_dir}/requirements.txt"; then
+if test -f "${app_dir}/requirements.txt.invalid"; then
   user_packages=$(sed '/^\s*#/d;/^\s*$/d' <"${app_dir}/requirements.txt" | wc -l)
   if [[ ${user_packages} == 0 ]]; then
     echo "No need to install anything..."

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -633,7 +633,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.nextSampleButton.setEnabled(self.ui.strategyBox.count)
 
         is_training_running = True if self.info and self.isTrainingRunning() else False
-        self.ui.trainingButton.setEnabled(self.info and not is_training_running)
+        self.ui.trainingButton.setEnabled(self.info and not is_training_running and current)
         self.ui.stopTrainingButton.setEnabled(is_training_running)
         self.ui.trainingStatusButton.setEnabled(self.info)
         if is_training_running and self.timer is None:


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

- Disable train button when no labels are available to train
- Don't use venv for train task (this feature is not completely supported during the app start).  So the user will install app/requirements.txt as mentioned in app readme before running his/her app in monailabel (example scribbles)