### PR TITLE
Scribbles - Copy WriteLogits functionality to generic segmentation app for non-coldstart scribbles methods

### DIFF
--- a/sample-apps/segmentation/lib/__init__.py
+++ b/sample-apps/segmentation/lib/__init__.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from .activelearning import MyStrategy
-from .infer import MyInfer
+from .infer import MyInferWithWriteLogits
 from .scribbles import (
     GenericInteractiveGraphCut,
     GenericISegCRF,

--- a/sample-apps/segmentation/main.py
+++ b/sample-apps/segmentation/main.py
@@ -10,15 +10,22 @@
 # limitations under the License.
 
 import logging
-from monailabel.interfaces.tasks.infer import InferType
 import os
 from distutils.util import strtobool
 
-from lib import GenericISegGraphCut, GenericISegGraphcutColdstart, GenericISegSimpleCRF, MyInferWithWriteLogits, MyStrategy, MyTrain
+from lib import (
+    GenericISegGraphCut,
+    GenericISegGraphcutColdstart,
+    GenericISegSimpleCRF,
+    MyInferWithWriteLogits,
+    MyStrategy,
+    MyTrain,
+)
 from monai.networks.layers import Norm
 from monai.networks.nets import UNet
 
 from monailabel.interfaces.app import MONAILabelApp
+from monailabel.interfaces.tasks.infer import InferType
 from monailabel.utils.activelearning.random import Random
 
 logger = logging.getLogger(__name__)
@@ -81,7 +88,7 @@ class MyApp(MONAILabelApp):
             "random": Random(),
             "first": MyStrategy(),
         }
-    
+
     def infer(self, request, datastore=None):
         image = request.get("image")
 


### PR DESCRIPTION
With the recent moving of scribbles functionality into generic segmentation app, I seem to have missed the WriteLogits functionality needed for non-coldstart scribbles options. 

This PR attempts to fix this.

- [x] Adding WriteLogits transform to Inferer
- [x] Adding additional code to main.py for handling datastore queries for saving/loading logits
- [x] Tested all three scribbles functionalities within the generic segmentation apps, this includes  1) coldstart, 2) graphcut + logits and 3) crf + logits 

Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>