### PR TITLE
Scribbles - Improving execution time for scribbles core transforms

### DIFF
--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -34,18 +34,18 @@ logger = logging.getLogger(__name__)
 # monai crf is optional import as it requires compiling monai C++/Cuda code
 monaicrf, has_monaicrf = optional_import("monai.networks.blocks", name="CRF")
 
-# simplecrf is option import as it requires compiling C++ code
+# simplecrf is optional import as it requires compiling C++ code
 densecrf, has_densecrf = optional_import("denseCRF")
 densecrf3d, has_densecrf3d = optional_import("denseCRF3D")
 
 softmax, has_softmax = optional_import("scipy.special", name="softmax")
 
-#####################################
+#######################################
 # Interactive Segmentation Transforms
 #
 # Base class for implementing common
-# functionality for int. seg. tx
-#####################################
+# functionality for interactive seg. tx
+#######################################
 class InteractiveSegmentationTransform(Transform):
     def _fetch_data(self, data, key):
         if key not in data.keys():
@@ -77,8 +77,8 @@ class InteractiveSegmentationTransform(Transform):
         return d
 
 
-#####################################
-#####################################
+#######################################
+#######################################
 
 #########################################
 #  Add Background Scribbles from bbox ROI
@@ -580,11 +580,6 @@ class ApplySimpleCRFOptimisationd(InteractiveSegmentationTransform):
         pairwise_term = self._fetch_data(d, self.pairwise)
 
         # SimpleCRF expects uint8 for pairwise_term
-        # scaling of pairwise_term handled in pre_transforms should be in range [0, 1]
-        # just in case it is needed, leaving a basic scaling method here
-        # min_p = pairwise_term.min()
-        # max_p = pairwise_term.max()
-        # pairwise_term = (((pairwise_term - min_p) / (max_p - min_p)) * 255).astype(np.uint8)
         pairwise_term = (pairwise_term * 255).astype(np.uint8)
 
         # prepare data for SimpleCRF's CRF

--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -393,7 +393,7 @@ class ApplyISegGraphCutPostProcd(InteractiveSegmentationTransform):
             # 2D is not yet tested within this framework
             post_proc_label = interactive_maxflow2d(image, prob, scribbles, lamda=self.lamda, sigma=self.sigma)
 
-        post_proc_label = np.expand_dims(post_proc_label, axis=0)
+        post_proc_label = np.expand_dims(post_proc_label, axis=0).astype(np.float32)
         d[self.post_proc_label] = post_proc_label
 
         return d
@@ -626,7 +626,7 @@ class ApplySimpleCRFOptimisationd(InteractiveSegmentationTransform):
 
             post_proc_label = densecrf.densecrf(pairwise_term, unary_term, simplecrf_params)
 
-        post_proc_label = np.expand_dims(post_proc_label, axis=0)
+        post_proc_label = np.expand_dims(post_proc_label, axis=0).astype(np.float32)
         d[self.post_proc_label] = post_proc_label
 
         return d
@@ -715,7 +715,7 @@ class ApplyGraphCutOptimisationd(InteractiveSegmentationTransform):
             # 2D is not yet tested within this framework
             post_proc_label = maxflow2d(pairwise_term, unary_term, lamda=self.lamda, sigma=self.sigma)
 
-        post_proc_label = np.expand_dims(post_proc_label, axis=0)
+        post_proc_label = np.expand_dims(post_proc_label, axis=0).astype(np.float32)
         d[self.post_proc_label] = post_proc_label
 
         return d

--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from copy import deepcopy
 from typing import Optional
 
@@ -27,6 +28,8 @@ from .utils import (
     maxflow2d,
     maxflow3d,
 )
+
+logger = logging.getLogger(__name__)
 
 # monai crf is optional import as it requires compiling monai C++/Cuda code
 monaicrf, has_monaicrf = optional_import("monai.networks.blocks", name="CRF")
@@ -53,7 +56,7 @@ class InteractiveSegmentationTransform(Transform):
     def _normalise_logits(self, data, axis=0):
         # check if logits is a true prob, if not then apply softmax
         if not np.allclose(np.sum(data, axis=axis), 1.0):
-            print("found non normalized logits, normalizing using Softmax")
+            logger.info("found non normalized logits, normalizing using Softmax")
             data = softmax(data, axis=axis)
 
         return data

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -47,76 +47,6 @@ def interactive_maxflow3d(image, prob, seed, lamda=5, sigma=0.1):
     return maxflow.interactive_maxflow3d(image, prob, seed, (lamda, sigma))
 
 
-# def make_iseg_unary(
-#     prob,
-#     scribbles,
-#     scribbles_bg_label=2,
-#     scribbles_fg_label=3,
-# ):
-#     """
-#     Implements ISeg unary term from the following paper:
-#     Wang, Guotai, et al. "Interactive medical image segmentation using deep learning with image-specific fine tuning."
-#     IEEE transactions on medical imaging 37.7 (2018): 1562-1573. (preprint: https://arxiv.org/pdf/1710.04043.pdf)
-#     ISeg unary term is constructed using Equation 7 on page 4 of the above mentioned paper.
-#     """
-
-#     # fetch the data for probabilities and scribbles
-#     prob_shape = list(prob.shape)
-#     scrib_shape = list(scribbles.shape)
-
-#     # check if they have compatible shapes
-#     if prob_shape[1:] != scrib_shape[1:]:
-#         raise ValueError("shapes for prob and scribbles dont match")
-
-#     # expected input shape is [1, X, Y, [Z]], exit if first dimension doesnt comply
-#     if scrib_shape[0] != 1:
-#         raise ValueError("scribbles should have single channel first, received {}".format(scrib_shape[0]))
-
-#     # unfold a single prob for background into bg/fg prob (if needed)
-#     if prob_shape[0] == 1:
-#         prob = np.concatenate([prob, 1.0 - prob], axis=0)
-
-#     background_pts = list(np.argwhere(scribbles == scribbles_bg_label))
-#     foreground_pts = list(np.argwhere(scribbles == scribbles_fg_label))
-
-#     # issue a warning if no scribbles detected, the algorithm will still work
-#     # just need to inform user/researcher - in case it is unexpected
-#     if len(background_pts) == 0:
-#         logging.info(
-#             "warning: no background scribbles received with label {}, available in scribbles {}".format(
-#                 scribbles_bg_label, np.unique(scribbles)
-#             )
-#         )
-
-#     if len(foreground_pts) == 0:
-#         logging.info(
-#             "warning: no foreground scribbles received with label {}, available in scribbles {}".format(
-#                 scribbles_fg_label, np.unique(scribbles)
-#             )
-#         )
-
-#     # copy probabilities
-#     unary_term = np.copy(prob)
-
-#     # for numerical stability, get rid of zeros
-#     # needed only for SimpleCRF's methods, as internally they take -log(P)
-#     eps = get_eps(unary_term)
-#     unary_term[unary_term == 0] += eps
-
-#     # update unary with Equation 7
-#     s_hat = [0] * len(background_pts) + [1] * len(foreground_pts)
-#     fg_bg_pts = background_pts + foreground_pts
-
-#     equal_term = 1.0 - eps
-#     no_equal_term = eps
-#     for s_h, fb_pt in zip(s_hat, fg_bg_pts):
-#         u_idx = tuple(fb_pt[1:])
-#         unary_term[(s_h,) + u_idx] = equal_term
-#         unary_term[(1 - s_h,) + u_idx] = no_equal_term
-
-#     return unary_term
-
-
 def make_iseg_unary(
     prob,
     scribbles,
@@ -168,35 +98,34 @@ def make_iseg_unary(
     unary_term = np.copy(prob)
 
     # for numerical stability, get rid of zeros
-    # needed only for SimpleCRF's methods, as internally they take -log(P)
     eps = get_eps(unary_term)
-    unary_term[unary_term == 0] += eps
-
-    # update unary with Equation 7
-    # s_hat = [0] * len(background_pts) + [1] * len(foreground_pts)
-    # fg_bg_pts = background_pts + foreground_pts
 
     equal_term = 1.0 - eps
     no_equal_term = eps
+
+    # update unary with Equation 7
     unary_term[mask] = equal_term
     mask = np.flip(mask, axis=0)
     unary_term[mask] = no_equal_term
-    # for s_h, fb_pt in zip(s_hat, fg_bg_pts):
-    #     u_idx = tuple(fb_pt[1:])
-    #     unary_term[(s_h,) + u_idx] = equal_term
-    #     unary_term[(1 - s_h,) + u_idx] = no_equal_term
 
     return unary_term
 
 
 def make_histograms(image, scrib, scribbles_bg_label, scribbles_fg_label, bins=32):
+    # collect background voxels
     values = image[scrib == scribbles_bg_label]
+    # generate histogram for background
     bg_hist, _ = np.histogram(values, bins=bins, range=(0, 1), density=True)
 
+    # collect foreground voxels
     values = image[scrib == scribbles_fg_label]
+    # generate histrogram for foreground
     fg_hist, fg_bin_edges = np.histogram(values, bins=bins, range=(0, 1), density=True)
 
+    # calculate scale to normalise histogram, such that it returns a true probability
     scale = fg_bin_edges[1] - fg_bin_edges[0]
+
+    # normalise histograms and return
     return (bg_hist * scale).astype(np.float32), (fg_hist * scale).astype(np.float32), fg_bin_edges
 
 
@@ -207,15 +136,19 @@ def make_likelihood_image_histogram(image, scrib, scribbles_bg_label, scribbles_
     if min_img < 0.0 or max_img > 1.0:
         image = (image - min_img) / (max_img - min_img)
 
+    # generate histograms for background/foreground
     bg_hist, fg_hist, bin_edges = make_histograms(image, scrib, scribbles_bg_label, scribbles_fg_label)
 
+    # lookup values for each voxel for generating background/foreground probabilityes
     dimage = np.digitize(image, bin_edges[:-1]) - 1
     fprob = fg_hist[dimage]
     bprob = bg_hist[dimage]
     retprob = np.concatenate([bprob, fprob], axis=0)
+
+    # renormalise
     retprob = softmax(retprob, axis=0)
 
-    # return label instead of probability
+    # if needed, convert to discrete labels instead of probability
     if not return_prob:
         retprob = np.expand_dims(np.argmax(retprob, axis=0), axis=0).astype(np.float32)
 

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -139,7 +139,7 @@ def make_likelihood_image_histogram(image, scrib, scribbles_bg_label, scribbles_
     # generate histograms for background/foreground
     bg_hist, fg_hist, bin_edges = make_histograms(image, scrib, scribbles_bg_label, scribbles_fg_label)
 
-    # lookup values for each voxel for generating background/foreground probabilityes
+    # lookup values for each voxel for generating background/foreground probabilities
     dimage = np.digitize(image, bin_edges[:-1]) - 1
     fprob = fg_hist[dimage]
     bprob = bg_hist[dimage]

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -47,6 +47,76 @@ def interactive_maxflow3d(image, prob, seed, lamda=5, sigma=0.1):
     return maxflow.interactive_maxflow3d(image, prob, seed, (lamda, sigma))
 
 
+# def make_iseg_unary(
+#     prob,
+#     scribbles,
+#     scribbles_bg_label=2,
+#     scribbles_fg_label=3,
+# ):
+#     """
+#     Implements ISeg unary term from the following paper:
+#     Wang, Guotai, et al. "Interactive medical image segmentation using deep learning with image-specific fine tuning."
+#     IEEE transactions on medical imaging 37.7 (2018): 1562-1573. (preprint: https://arxiv.org/pdf/1710.04043.pdf)
+#     ISeg unary term is constructed using Equation 7 on page 4 of the above mentioned paper.
+#     """
+
+#     # fetch the data for probabilities and scribbles
+#     prob_shape = list(prob.shape)
+#     scrib_shape = list(scribbles.shape)
+
+#     # check if they have compatible shapes
+#     if prob_shape[1:] != scrib_shape[1:]:
+#         raise ValueError("shapes for prob and scribbles dont match")
+
+#     # expected input shape is [1, X, Y, [Z]], exit if first dimension doesnt comply
+#     if scrib_shape[0] != 1:
+#         raise ValueError("scribbles should have single channel first, received {}".format(scrib_shape[0]))
+
+#     # unfold a single prob for background into bg/fg prob (if needed)
+#     if prob_shape[0] == 1:
+#         prob = np.concatenate([prob, 1.0 - prob], axis=0)
+
+#     background_pts = list(np.argwhere(scribbles == scribbles_bg_label))
+#     foreground_pts = list(np.argwhere(scribbles == scribbles_fg_label))
+
+#     # issue a warning if no scribbles detected, the algorithm will still work
+#     # just need to inform user/researcher - in case it is unexpected
+#     if len(background_pts) == 0:
+#         logging.info(
+#             "warning: no background scribbles received with label {}, available in scribbles {}".format(
+#                 scribbles_bg_label, np.unique(scribbles)
+#             )
+#         )
+
+#     if len(foreground_pts) == 0:
+#         logging.info(
+#             "warning: no foreground scribbles received with label {}, available in scribbles {}".format(
+#                 scribbles_fg_label, np.unique(scribbles)
+#             )
+#         )
+
+#     # copy probabilities
+#     unary_term = np.copy(prob)
+
+#     # for numerical stability, get rid of zeros
+#     # needed only for SimpleCRF's methods, as internally they take -log(P)
+#     eps = get_eps(unary_term)
+#     unary_term[unary_term == 0] += eps
+
+#     # update unary with Equation 7
+#     s_hat = [0] * len(background_pts) + [1] * len(foreground_pts)
+#     fg_bg_pts = background_pts + foreground_pts
+
+#     equal_term = 1.0 - eps
+#     no_equal_term = eps
+#     for s_h, fb_pt in zip(s_hat, fg_bg_pts):
+#         u_idx = tuple(fb_pt[1:])
+#         unary_term[(s_h,) + u_idx] = equal_term
+#         unary_term[(1 - s_h,) + u_idx] = no_equal_term
+
+#     return unary_term
+
+
 def make_iseg_unary(
     prob,
     scribbles,
@@ -76,19 +146,18 @@ def make_iseg_unary(
     if prob_shape[0] == 1:
         prob = np.concatenate([prob, 1.0 - prob], axis=0)
 
-    background_pts = list(np.argwhere(scribbles == scribbles_bg_label))
-    foreground_pts = list(np.argwhere(scribbles == scribbles_fg_label))
+    mask = np.concatenate([scribbles == scribbles_bg_label, scribbles == scribbles_fg_label], axis=0)
 
     # issue a warning if no scribbles detected, the algorithm will still work
     # just need to inform user/researcher - in case it is unexpected
-    if len(background_pts) == 0:
+    if not np.any(mask[0, ...]):
         logging.info(
             "warning: no background scribbles received with label {}, available in scribbles {}".format(
                 scribbles_bg_label, np.unique(scribbles)
             )
         )
 
-    if len(foreground_pts) == 0:
+    if not np.any(mask[1, ...]):
         logging.info(
             "warning: no foreground scribbles received with label {}, available in scribbles {}".format(
                 scribbles_fg_label, np.unique(scribbles)
@@ -104,31 +173,27 @@ def make_iseg_unary(
     unary_term[unary_term == 0] += eps
 
     # update unary with Equation 7
-    s_hat = [0] * len(background_pts) + [1] * len(foreground_pts)
-    fg_bg_pts = background_pts + foreground_pts
+    # s_hat = [0] * len(background_pts) + [1] * len(foreground_pts)
+    # fg_bg_pts = background_pts + foreground_pts
 
     equal_term = 1.0 - eps
     no_equal_term = eps
-    for s_h, fb_pt in zip(s_hat, fg_bg_pts):
-        u_idx = tuple(fb_pt[1:])
-        unary_term[(s_h,) + u_idx] = equal_term
-        unary_term[(1 - s_h,) + u_idx] = no_equal_term
+    unary_term[mask] = equal_term
+    mask = np.flip(mask, axis=0)
+    unary_term[mask] = no_equal_term
+    # for s_h, fb_pt in zip(s_hat, fg_bg_pts):
+    #     u_idx = tuple(fb_pt[1:])
+    #     unary_term[(s_h,) + u_idx] = equal_term
+    #     unary_term[(1 - s_h,) + u_idx] = no_equal_term
 
     return unary_term
 
 
 def make_histograms(image, scrib, scribbles_bg_label, scribbles_fg_label, bins=32):
-    def get_values(_data, _seed, _label):
-        idx = np.argwhere(_seed == _label)
-        _values = []
-        for id in idx:
-            _values.append(_data[tuple(id)])
-        return _values
+    values = image[scrib == scribbles_bg_label]
+    bg_hist, _ = np.histogram(values, bins=bins, range=(0, 1), density=True)
 
-    values = get_values(image, scrib, scribbles_bg_label)
-    bg_hist, bg_bin_edges = np.histogram(values, bins=bins, range=(0, 1), density=True)
-
-    values = get_values(image, scrib, scribbles_fg_label)
+    values = image[scrib == scribbles_fg_label]
     fg_hist, fg_bin_edges = np.histogram(values, bins=bins, range=(0, 1), density=True)
 
     scale = fg_bin_edges[1] - fg_bin_edges[0]


### PR DESCRIPTION
This PR attempts to speedup the execution of following scribbles transforms:
- `MakeLikelihoodFromScribblesHistogramd`
- `MakeISegUnaryd`

As a combination of both is used in all current scribbles flow, therefore this will improve execution time of all current scribbles flows.

As an example, the following are timing **before** this PR for a **coldstart scribbles task**:
++ Latencies => **Total: 9.4925; Pre: 4.2495; Inferer: 4.5903;** Invert: 0.0000; Post: 0.1111; Write: 0.5415

and **after** this PR, for the same task, these will be reduced to:
++ Latencies => **Total: 3.2419; Pre: 1.6300; Inferer: 0.9109;** Invert: 0.0000; Post: 0.1176; Write: 0.5833

This is about **3x** improvement for overall execution and around **5x** improvement for Pre/Inferer execution.

Most of the changes are in favour of using numpy in-built functions for filtering/applying scribbles update instead of previously used list/collection based updates. This allows us to benefit from numpy's already optimised methods.

- [x] Update `MakeLikelihoodFromScribblesHistogramd` to use numpy functions for building histograms
- [x] Update `MakeISegUnaryd` to use numpy functions for filtering/applying scribbles based updates to build unary terms
- [x]  Testing  working example of each scribbles flow which includes 1) coldstart, 2) graphcut + logits and 3) crf + logits.
 
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>