### PR TITLE
Sanity check in planner - Add single modality transform

### DIFF
--- a/monailabel/deepedit/transforms.py
+++ b/monailabel/deepedit/transforms.py
@@ -291,3 +291,49 @@ class PosNegClickProbAddRandomGuidanced(Randomizable, Transform):
         self.is_pos = False
         self.is_neg = False
         return d
+
+
+# A transform to get single modality and single label
+class SingleLabelSingleModalityd(MapTransform):
+    """
+    Gets single modality and single label
+    """
+
+    def __call__(self, data):
+        d = dict(data)
+        for key in self.keys:
+            if key == "label":
+                meta_data = d["label_meta_dict"]
+                if d[key].max() > 1:
+                    logger.info(
+                        f"Label {meta_data['filename_or_obj'].split('/')[-1]} has more than one mask - "
+                        f"taking SINGLE mask ..."
+                    )
+                    result = []
+                    # label bigger than 0 is foreground
+                    result.append(d[key] > 0)
+                    # label 0 is background
+                    result.append(d[key] == 0)
+                    d[key] = np.stack(result, axis=0).astype(np.float32)
+
+                    d[key] = d[key][0, ...]
+
+                    meta_data["pixdim"][4] = 0.0
+                    meta_data["dim"][0] = 3
+                    meta_data["dim"][4] = 1
+
+            if key == "image":
+                meta_data = d["image_meta_dict"]
+                if meta_data["pixdim"][4] > 0:
+                    logger.info(
+                        f"Image {meta_data['filename_or_obj'].split('/')[-1]} has more than one modality "
+                        f"- taking FIRST modality ..."
+                    )
+
+                    d[key] = d[key][..., 0]
+
+                    meta_data["pixdim"][4] = 0.0
+                    meta_data["dim"][0] = 3
+                    meta_data["dim"][4] = 1
+
+        return d

--- a/monailabel/utils/scoring/tta.py
+++ b/monailabel/utils/scoring/tta.py
@@ -31,7 +31,7 @@ from monai.transforms import (
     ToTensord,
 )
 
-from monailabel.deepedit.transforms import DiscardAddGuidanced
+from monailabel.deepedit.transforms import DiscardAddGuidanced, SingleLabelSingleModalityd
 from monailabel.interfaces.datastore import Datastore
 from monailabel.interfaces.tasks.scoring import ScoringMethod
 from monailabel.utils.infer.test_time_augmentation import TestTimeAugmentation
@@ -55,7 +55,8 @@ class TTAScoring(ScoringMethod):
 
     def pre_transforms(self):
         t = [
-            LoadImaged(keys="image"),
+            LoadImaged(keys="image", reader="nibabelreader"),
+            SingleLabelSingleModalityd(keys="image"),
             AddChanneld(keys="image"),
             Spacingd(keys="image", pixdim=[1.0, 1.0, 1.0]),
             RandAffined(

--- a/sample-apps/deepedit/lib/infer.py
+++ b/sample-apps/deepedit/lib/infer.py
@@ -25,7 +25,7 @@ from monai.transforms import (
     ToTensord,
 )
 
-from monailabel.deepedit.transforms import DiscardAddGuidanced, ResizeGuidanceCustomd
+from monailabel.deepedit.transforms import DiscardAddGuidanced, ResizeGuidanceCustomd, SingleLabelSingleModalityd
 from monailabel.interfaces.tasks.infer import InferTask, InferType
 from monailabel.utils.others.post import Restored
 
@@ -63,7 +63,8 @@ class Segmentation(InferTask):
 
     def pre_transforms(self):
         return [
-            LoadImaged(keys="image"),
+            LoadImaged(keys="image", reader="nibabelreader"),
+            SingleLabelSingleModalityd(keys="image"),
             AddChanneld(keys="image"),
             Spacingd(keys="image", pixdim=self.target_spacing, mode="bilinear"),
             Orientationd(keys="image", axcodes="RAS"),
@@ -119,7 +120,8 @@ class Deepgrow(InferTask):
 
     def pre_transforms(self):
         return [
-            LoadImaged(keys="image"),
+            LoadImaged(keys="image", reader="nibabelreader"),
+            SingleLabelSingleModalityd(keys="image"),
             AddChanneld(keys="image"),
             Spacingd(keys="image", pixdim=self.target_spacing, mode="bilinear"),
             Orientationd(keys="image", axcodes="RAS"),

--- a/sample-apps/deepedit/lib/train.py
+++ b/sample-apps/deepedit/lib/train.py
@@ -38,7 +38,7 @@ from monai.transforms import (
 
 from monailabel.deepedit.handlers import TensorBoardImageHandler
 from monailabel.deepedit.interaction import Interaction
-from monailabel.deepedit.transforms import PosNegClickProbAddRandomGuidanced
+from monailabel.deepedit.transforms import PosNegClickProbAddRandomGuidanced, SingleLabelSingleModalityd
 from monailabel.utils.train.basic_train import BasicTrainTask
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,8 @@ class MyTrain(BasicTrainTask):
 
     def train_pre_transforms(self):
         return [
-            LoadImaged(keys=("image", "label")),
+            LoadImaged(keys=("image", "label"), reader="nibabelreader"),
+            SingleLabelSingleModalityd(keys=("image", "label")),
             # RandZoomd(keys=("image", "label"), prob=0.4, min_zoom=0.3, max_zoom=1.9, mode=("bilinear", "nearest")),
             AddChanneld(keys=("image", "label")),
             Spacingd(keys=["image", "label"], pixdim=self.target_spacing, mode=("bilinear", "nearest")),
@@ -125,7 +126,8 @@ class MyTrain(BasicTrainTask):
 
     def val_pre_transforms(self):
         return [
-            LoadImaged(keys=("image", "label")),
+            LoadImaged(keys=("image", "label"), reader="nibabelreader"),
+            SingleLabelSingleModalityd(keys=("image", "label")),
             AddChanneld(keys=("image", "label")),
             Spacingd(keys=["image", "label"], pixdim=self.target_spacing, mode=("bilinear", "nearest")),
             Orientationd(keys=["image", "label"], axcodes="RAS"),


### PR DESCRIPTION
Signed-off-by: Andres <diazandr3s@gmail.com>

- Modify planner to randomly read max 20 images
- Log a warning when detecting multimodality images in the datastore
- Create transform to reduce multimodality images into single modality and multilabel into a single label