### PR TITLE
Scribbles - Improve scribbles ROI to work when no fg scribbles are given

### DIFF
--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -121,6 +121,24 @@ class AddBackgroundScribblesFromROId(InteractiveSegmentationTransform):
             # prune outside roi region as bg scribbles
             scribbles[mask] = self.scribbles_bg_label
 
+            # if no foreground scribbles found, then add a scribble at centre of roi
+            if not np.any(scribbles == self.scribbles_fg_label):
+                # issue a small warning - the algorithm should still work
+                logging.info(
+                    "warning: no foreground scribbles received with label {}, adding foreground scribbles to ROI centre".format(
+                        self.scribbles_fg_label
+                    )
+                )
+                offset = 5
+
+                cx = int((selected_roi[0] + selected_roi[1]) / 2)
+                cy = int((selected_roi[2] + selected_roi[3]) / 2)
+                cz = int((selected_roi[4] + selected_roi[5]) / 2)
+
+                scribbles[
+                    :, cx - offset : cx + offset, cy - offset : cy + offset, cz - offset : cz + offset
+                ] = self.scribbles_fg_label
+
         # return new scribbles
         d[self.scribbles] = scribbles
 

--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -121,9 +121,9 @@ class AddBackgroundScribblesFromROId(InteractiveSegmentationTransform):
             # prune outside roi region as bg scribbles
             scribbles[mask] = self.scribbles_bg_label
 
-            # if no foreground scribbles found, then add a scribble at centre of roi
+            # if no foreground scribbles found, then add a scribble at center of roi
             if not np.any(scribbles == self.scribbles_fg_label):
-                # issue a small warning - the algorithm should still work
+                # issue a warning - the algorithm should still work
                 logging.info(
                     "warning: no foreground scribbles received with label {}, adding foreground scribbles to ROI centre".format(
                         self.scribbles_fg_label
@@ -135,6 +135,7 @@ class AddBackgroundScribblesFromROId(InteractiveSegmentationTransform):
                 cy = int((selected_roi[2] + selected_roi[3]) / 2)
                 cz = int((selected_roi[4] + selected_roi[5]) / 2)
 
+                # add scribbles at center of roi
                 scribbles[
                     :, cx - offset : cx + offset, cy - offset : cy + offset, cz - offset : cz + offset
                 ] = self.scribbles_fg_label


### PR DESCRIPTION
This PR adds a simple mechanism to automatically add foreground scribbles when an ROI is given but user has not provided  foreground scribbles yet. The FG scribbles added are at the center of ROI assuming that ROI is centered around foreground object. 

This enables it to work in such interaction (i.e. when only an ROI is given and histgramBasedGraphCut is applied). FG/BG scribbles are still needed for further correction. 

Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>