### PR TITLE
Remove Python3.6 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code=https://github.com/Project-MONAI/MONAILabel
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 # for compiling and develop setup only
 # no need to specify the versions so that we could
 # compile for multiple targeted versions.


### PR DESCRIPTION
New Azure test suite runs all tests using python 3.6-3.9. On version 3.6 the integration tests do not pass.
Bumping the description for Pypi to say minimum version is Python3.7