### PR TITLE
CI/CD: Add Azure CI Pipelines

### DIFF
--- a/.azure/azure-build-test-pipeline.yml
+++ b/.azure/azure-build-test-pipeline.yml
@@ -1,0 +1,110 @@
+trigger:
+  - main
+
+pr: 
+  - main
+  
+stages:
+  - stage: 'Test'
+    jobs:
+    - job: RunTests
+      pool:
+        vmImage: ubuntu-20.04
+      strategy:
+        matrix:
+          Python3.7:
+            python.version: '3.7'
+          Python3.8:
+            python.version: '3.8'
+          Python3.9:
+            python.version: '3.9'
+        maxParallel: 3
+      steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(python.version)
+      - script: |
+          python3 -m pip install --upgrade pip wheel
+          python3 -m pip install -r requirements-dev.txt
+        displayName: 'Install dependencies'
+      - bash:  $(pwd)/runtests.sh --clean
+        displayName: 'Clean'
+      - bash: $(pwd)/runtests.sh --isort
+        displayName: 'iSort'
+      - bash: $(pwd)/runtests.sh --black
+        displayName: 'Black'
+      - script: |
+          $(pwd)/runtests.sh --flake8
+        displayName: 'Flake8'
+      - bash:  $(pwd)/runtests.sh --pytype
+        displayName: 'PyType'
+      - bash:  $(pwd)/runtests.sh --mypy
+        displayName: 'MyPy'
+      - bash:  $(pwd)/runtests.sh --unittests --coverage
+        displayName: 'Unit tests'
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: ./coverage.xml
+        displayName: 'Publish Code Coverage Results'
+  
+  - stage: Build
+    jobs:
+    - job: Package
+    pool:
+      vmImage: ubuntu-20.04
+      strategy:
+        matrix:
+          Python38:
+            python.version: '3.8'
+      steps:
+        - script: |
+            python3 -m pip install --user --upgrade pip setuptools wheel twine
+            python3 -m pip install torch>=1.5 torchvision
+          displayName: 'Install dependencies'
+        - script: |
+            root_dir=$PWD
+            echo "$root_dir"
+  
+            # build tar.gz and wheel
+            export BUILD_OHIF=true
+            python setup.py check -m -s
+            python setup.py sdist bdist_wheel
+            python -m twine check dist/*
+  
+            # move packages to a temp dir
+            tmp_dir=$(mktemp -d)
+            cp dist/monailabel* "$tmp_dir"
+            rm -r build dist monailabel.egg-info
+            cd "$tmp_dir"
+            ls -al
+  
+            # install from wheel
+            python -m pip install monailabel*.whl
+            python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
+            python -c 'import monailabel; print(monailabel.__file__)'
+            python -m pip uninstall -y monailabel
+            rm monailabel*.whl
+  
+            # install from tar.gz
+            name=$(ls *.tar.gz | head -n1)
+            echo $name
+            python -m pip install $name
+            python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
+            python -c 'import monailabel; print(monailabel.__file__)'
+  
+            # install test utilities
+            python -m pip install pytest
+  
+            # start the monailabel server in the background and run the integration tests
+            $root_dir/runtests.sh --net
+          env:
+            shell: bash
+        - script: |
+            python -m pip install -r docs/requirements.txt
+            export PYTHONPATH=$(pwd)
+            cd docs/
+            make clean
+            make html 2>&1 | tee tmp_log
+            if [[ $(grep -c "WARNING:" tmp_log) != 0 ]]; then echo "found warnings"; grep "WARNING:" tmp_log; exit 1; fi
+          displayName: 'Build Docs'

--- a/.azure/azure-release-pipeline.yml
+++ b/.azure/azure-release-pipeline.yml
@@ -1,7 +1,4 @@
-trigger:
-  tags:
-    include:
-      - '*'
+trigger: never
 stages:
   - stage: 'Build'
     jobs:

--- a/.azure/azure-release-pipeline.yml
+++ b/.azure/azure-release-pipeline.yml
@@ -1,0 +1,75 @@
+trigger:
+  tags:
+    include:
+      - '*'
+stages:
+  - stage: 'Build'
+    jobs:
+    - job: RunTests
+      pool:
+        vmImage: ubuntu-20.04
+        strategy:
+          matrix:
+            Python38:
+              python.version: '3.8'
+          maxParallel: 1
+      steps:
+      - script: |
+          python -m pip install --user --upgrade pip setuptools wheel twine
+          python -m pip install torch>=1.5 torchvision
+        displayName: 'Install dependencies'
+      - script: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          root_dir=$PWD
+          echo "$root_dir"
+          set -e
+  
+          # move packages to a temp dir
+          export BUILD_OHIF=true
+          python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
+          tmp_dir=$(mktemp -d)
+          cp dist/monailabel* "$tmp_dir"
+          rm -r build monailabel.egg-info
+          cd "$tmp_dir"
+          ls -al
+  
+          # install from tar.gz
+          python -m pip install monailabel*.tar.gz
+          python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
+          python -c 'import monailabel; print(monailabel.__file__)'
+          python -m pip uninstall -y monailabel
+          rm monailabel*.tar.gz
+  
+          # install from wheel
+          python -m pip install monailabel*.whl
+          python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
+          python -c 'import monailabel; print(monailabel.__file__)'
+          python -m pip uninstall -y monailabel
+          rm monailabel*.whl
+  
+          # install test utilities
+          python -m pip install pytest
+  
+          # start the monailabel server in the background
+          # and run the integration tests
+          $root_dir/runtests.sh --net
+  
+          # cleanup
+          cd "$root_dir"
+          rm -r "$tmp_dir"
+          rm -rf monailabel/
+          ls -la .
+        displayName: 'Build and test source archive and wheel file'
+      - task: GitHubRelease@0
+        inputs:
+          gitHubConnection: monailabel
+          repositoryName: '$(Build.Repository.Name)'
+          action: 'create'
+          # target: '$(tagName)'
+          tagSource: 'manual'
+          tag: 0.2.0
+          addChangeLog: true 
+          compareWith: 'lastRelease' 
+          releaseTag: 0.2.0
+          assets: '$(Build.ArtifactStagingDirectory)/*'
+  


### PR DESCRIPTION
Opening this PR (again) but this time from a branch instead of my fork.

This PR adds a .azure directory for Azure pipelines with one for Build+Test & one for Release.

These can be tested within the current system since this PR does not remove current GitHub actions.