### PR TITLE
Add Python 3.6 to Azure Build-test pipeline

### DIFF
--- a/.azure/azure-build-test-pipeline.yml
+++ b/.azure/azure-build-test-pipeline.yml
@@ -12,6 +12,8 @@ stages:
         vmImage: ubuntu-20.04
       strategy:
         matrix:
+          Python3.6:
+            python.version: '3.6'
           Python3.7:
             python.version: '3.7'
           Python3.8:


### PR DESCRIPTION
Add python3.6 to Azure pipeline CI test matrix (to be executed on every PR)