### PR TITLE
Remove redundant Windows-specific backslash alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,8 @@ To install the current release, you can simply run:
   monailabel apps --download --name deepedit --output apps
   monailabel datasets --download --name Task02_Heart --output datasets
   
-  # run server (ubuntu)
+  # run server
   monailabel start_server --app apps/deepedit --studies datasets/Task02_Heart/imagesTr
-
-  # run server (windows)
-  monailabel start_server --app apps\deepedit --studies datasets\Task02_Heart\imagesTr
-  
 ```
 
 For **_prerequisites_**, other installation methods (using the default GitHub branch, using Docker, etc.), please refer


### PR DESCRIPTION
As Windows also supports forward slash, I see no reason to have two separate alternatives for each operating system. 

One could simply use the Ubuntu-specific command for Windows as well.

The current version makes the release installation OS-invariant (at least for Windows/Ubuntu), which is cleaner.

Or is there something I am missing?