### PR TITLE
Attempting to update simplecrf version to latest 0.2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ pynetdicom==1.5.7
 expiringdict==1.2.1
 schedule==1.1.0
 timeloop==1.0.2
-https://github.com/masadcv/SimpleCRF/archive/refs/tags/v0.1.1.tar.gz#egg=simplecrf
+simplecrf==0.2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,7 @@ install_requires =
     expiringdict==1.2.1
     schedule==1.1.0
     timeloop==1.0.2
-    simplecrf
-dependency_links =
-    https://github.com/masadcv/SimpleCRF/archive/refs/tags/v0.1.1.tar.gz#egg=simplecrf-0.1.1
-    
+    simplecrf==0.2.1.1    
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

simplecrf has a new release. This may address the earlier issues we had to install previous versions of it.

This PR attempts to try version simplecrf version 0.2.1.1

