### PR TITLE
Add option to fetch unnormalised histogram likelihoods

### DIFF
--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -82,7 +82,12 @@ class HistogramBasedGraphCut(InferTask):
                 clip=self.intensity_range[4],
             ),
             MakeLikelihoodFromScribblesHistogramd(
-                image="image", scribbles="label", post_proc_label="prob", scribbles_bg_label=2, scribbles_fg_label=3
+                image="image",
+                scribbles="label",
+                post_proc_label="prob",
+                scribbles_bg_label=2,
+                scribbles_fg_label=3,
+                normalise=True,
             ),
         ]
 

--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -155,6 +155,7 @@ class MakeLikelihoodFromScribblesHistogramd(InteractiveSegmentationTransform):
         post_proc_label: str = "prob",
         scribbles_bg_label: int = 2,
         scribbles_fg_label: int = 3,
+        normalise: bool = True,
     ) -> None:
         super().__init__(meta_key_postfix)
         self.image = image
@@ -162,6 +163,7 @@ class MakeLikelihoodFromScribblesHistogramd(InteractiveSegmentationTransform):
         self.scribbles_bg_label = scribbles_bg_label
         self.scribbles_fg_label = scribbles_fg_label
         self.post_proc_label = post_proc_label
+        self.normalise = normalise
 
     def __call__(self, data):
         d = dict(data)
@@ -179,8 +181,12 @@ class MakeLikelihoodFromScribblesHistogramd(InteractiveSegmentationTransform):
             scribbles,
             scribbles_bg_label=self.scribbles_bg_label,
             scribbles_fg_label=self.scribbles_fg_label,
-            return_prob=True,
+            return_label=False,
         )
+
+        if self.normalise:
+            post_proc_label = self._normalise_logits(post_proc_label, axis=0)
+
         d[self.post_proc_label] = post_proc_label
 
         return d

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -12,7 +12,6 @@ import logging
 
 import maxflow
 import numpy as np
-from scipy.special import softmax
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +155,7 @@ def make_histograms(image, scrib, scribbles_bg_label, scribbles_fg_label, alpha_
     return bg_hist.astype(np.float32), fg_hist.astype(np.float32), fg_bin_edges.astype(np.float32)
 
 
-def make_likelihood_image_histogram(image, scrib, scribbles_bg_label, scribbles_fg_label, return_prob=True):
+def make_likelihood_image_histogram(image, scrib, scribbles_bg_label, scribbles_fg_label, return_label=False):
     # normalise image in range [0, 1] if needed
     min_img = np.min(image)
     max_img = np.max(image)
@@ -174,11 +173,8 @@ def make_likelihood_image_histogram(image, scrib, scribbles_bg_label, scribbles_
     bprob = bg_hist[dimage]
     retprob = np.concatenate([bprob, fprob], axis=0)
 
-    # renormalise
-    retprob = softmax(retprob, axis=0)
-
     # if needed, convert to discrete labels instead of probability
-    if not return_prob:
+    if return_label:
         retprob = np.expand_dims(np.argmax(retprob, axis=0), axis=0).astype(np.float32)
 
     return retprob


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

Some methods, e.g. Geos: https://link.springer.com/chapter/10.1007/978-3-540-88682-2_9 require unnormalised histogram likelihoods. Hence this PR enables to operate histogram likelihood transform in both normalised and unnormalised modes. 