### PR TITLE
enable coverage upload only for PRs in github workflow

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           coverage xml
       - name: Upload coverage
+        if: ${{ github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>
Coverage report consumes report per commit id.. multiple uploads are rejected.

Azure tries to upload coverage report with GPU and gets discarded as github action has already uploaded a coverage report