### PR TITLE
Revert "enable coverage upload only for PRs in github workflow"

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           coverage xml
       - name: Upload coverage
-        if: ${{ github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
Reverts Project-MONAI/MONAILabel#527

In case if my assumption is wrong.. let @evberrypi confirm why the coverage report is not getting pushed from azure to https://app.codecov.io/gh/Project-MONAI/MONAILabel