### PR TITLE
Add property to Slicer plugin to automatically open segment editor after next sample was fetched

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -124,18 +124,7 @@ class _ui_MONAILabelSettingsPanel(object):
             "valueAsInt",
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
-        
-        autoOpenSegmentEditorCheckBox = qt.QCheckBox()
-        autoOpenSegmentEditorCheckBox.checked = False
-        autoOpenSegmentEditorCheckBox.toolTip = "Enable this option to automatically open segment editor after Next Sample was fetched"
-        groupLayout.addRow("Auto-Open Segment Editor:", autoOpenSegmentEditorCheckBox)
-        parent.registerProperty(
-            "MONAILabel/autoOpenSegmentEditor",
-            ctk.ctkBooleanMapper(autoOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
-            "valueAsInt",
-            str(qt.SIGNAL("valueAsIntChanged(int)")),
-        )
-        
+
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -912,8 +901,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.info = info
             if self.info.get("config"):
                 slicer.util.errorDisplay(
-                    "Please upgrade the monai server to latest version",
-                    detailedText=traceback.format_exc(),
+                    "Please upgrade the monai server to latest version", detailedText=traceback.format_exc(),
                 )
                 return
         except:
@@ -992,9 +980,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if status:
             msg = "ID: {}\nStatus: {}\nStart Time: {}\n".format(
-                status.get("id"),
-                status.get("status"),
-                status.get("start_ts"),
+                status.get("id"), status.get("status"), status.get("start_ts"),
             )
             # slicer.util.infoDisplay(msg, detailedText=json.dumps(status, indent=2))
             logging.info(msg)
@@ -1134,11 +1120,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         self.ui.segmentationModelSelector.currentText = name
                         self.onClickSegmentation()
                         return
-        
-        # Check if user wants to automatically open segment editor after next sample was fetched
-        if slicer.util.settingsValue("MONAILabel/autoOpenSegmentEditor", False, converter=slicer.util.toBool):
-            slicer.util.selectModule("SegmentEditor")  
-    
+
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(
             "Master volume - without any additional patient information -"
@@ -1217,10 +1199,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
             qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
             segmentationNode = self._segmentNode
-            labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
-            slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
-                segmentationNode, labelmapVolumeNode, self._volumeNode
-            )
+            # labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+            # slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
+            # segmentationNode, labelmapVolumeNode, self._volumeNode
+            # )
 
             segmentation = segmentationNode.GetSegmentation()
             totalSegments = segmentation.GetNumberOfSegments()
@@ -1240,7 +1222,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            slicer.util.saveNode(labelmapVolumeNode, label_in)
+            # slicer.util.saveNode(labelmapVolumeNode, label_in)
+            slicer.util.saveNode(segmentationNode, label_in)
             self.reportProgress(30)
 
             self.updateServerSettings()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -125,13 +125,13 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
         
-        autOpenSegmentEditorCheckBox = qt.QCheckBox()
-        autOpenSegmentEditorCheckBox.checked = False
-        autOpenSegmentEditorCheckBox.toolTip = "Enable this option to automatically open segment editor after Next Sample was fetched"
-        groupLayout.addRow("Auto-Open Segment Editor:", autOpenSegmentEditorCheckBox)
+        autoOpenSegmentEditorCheckBox = qt.QCheckBox()
+        autoOpenSegmentEditorCheckBox.checked = False
+        autoOpenSegmentEditorCheckBox.toolTip = "Enable this option to automatically open segment editor after Next Sample was fetched"
+        groupLayout.addRow("Auto-Open Segment Editor:", autoOpenSegmentEditorCheckBox)
         parent.registerProperty(
             "MONAILabel/autoOpenSegmentEditor",
-            ctk.ctkBooleanMapper(autOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            ctk.ctkBooleanMapper(autoOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
             "valueAsInt",
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -124,6 +124,17 @@ class _ui_MONAILabelSettingsPanel(object):
             "valueAsInt",
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
+        
+        autOpenSegmentEditorCheckBox = qt.QCheckBox()
+        autOpenSegmentEditorCheckBox.checked = False
+        autOpenSegmentEditorCheckBox.toolTip = "Enable this option to automatically open segment editor after Next Sample was fetched"
+        groupLayout.addRow("Auto-Open Segment Editor:", autOpenSegmentEditorCheckBox)
+        parent.registerProperty(
+            "MONAILabel/autoOpenSegmentEditor",
+            ctk.ctkBooleanMapper(autOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
 
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
@@ -1123,6 +1134,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         self.ui.segmentationModelSelector.currentText = name
                         self.onClickSegmentation()
                         return
+                    
+        # Check if user wants to automatically open segment editor after next sample was fetched
+        if slicer.util.settingsValue("MONAILabel/autoOpenSegmentEditor", False, converter=slicer.util.toBool):
+            slicer.util.selectModule("SegmentEditor")  
 
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -135,7 +135,7 @@ class _ui_MONAILabelSettingsPanel(object):
             "valueAsInt",
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
-
+        
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -1134,11 +1134,11 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         self.ui.segmentationModelSelector.currentText = name
                         self.onClickSegmentation()
                         return
-                    
+        
         # Check if user wants to automatically open segment editor after next sample was fetched
         if slicer.util.settingsValue("MONAILabel/autoOpenSegmentEditor", False, converter=slicer.util.toBool):
             slicer.util.selectModule("SegmentEditor")  
-
+    
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(
             "Master volume - without any additional patient information -"

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -125,6 +125,19 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        autoOpenSegmentEditorCheckBox = qt.QCheckBox()
+        autoOpenSegmentEditorCheckBox.checked = False
+        autoOpenSegmentEditorCheckBox.toolTip = (
+            "Enable this option to automatically open segment editor after Next Sample was fetched"
+        )
+        groupLayout.addRow("Auto-Open Segment Editor:", autoOpenSegmentEditorCheckBox)
+        parent.registerProperty(
+            "MONAILabel/autoOpenSegmentEditor",
+            ctk.ctkBooleanMapper(autoOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -1121,6 +1134,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         self.onClickSegmentation()
                         return
 
+        # Check if user wants to automatically open segment editor after next sample was fetched
+        if slicer.util.settingsValue("MONAILabel/autoOpenSegmentEditor", False, converter=slicer.util.toBool):
+            slicer.util.selectModule("SegmentEditor")
+
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(
             "Master volume - without any additional patient information -"
@@ -1199,10 +1216,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
             qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
             segmentationNode = self._segmentNode
-            # labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
-            # slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
-            # segmentationNode, labelmapVolumeNode, self._volumeNode
-            # )
+            labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+            slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
+                segmentationNode, labelmapVolumeNode, self._volumeNode
+            )
 
             segmentation = segmentationNode.GetSegmentation()
             totalSegments = segmentation.GetNumberOfSegments()
@@ -1222,8 +1239,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            # slicer.util.saveNode(labelmapVolumeNode, label_in)
-            slicer.util.saveNode(segmentationNode, label_in)
+            slicer.util.saveNode(labelmapVolumeNode, label_in)
             self.reportProgress(30)
 
             self.updateServerSettings()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -914,7 +914,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.info = info
             if self.info.get("config"):
                 slicer.util.errorDisplay(
-                    "Please upgrade the monai server to latest version", detailedText=traceback.format_exc(),
+                    "Please upgrade the monai server to latest version",
+                    detailedText=traceback.format_exc(),
                 )
                 return
         except:
@@ -993,7 +994,9 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if status:
             msg = "ID: {}\nStatus: {}\nStart Time: {}\n".format(
-                status.get("id"), status.get("status"), status.get("start_ts"),
+                status.get("id"),
+                status.get("status"),
+                status.get("start_ts"),
             )
             # slicer.util.infoDisplay(msg, detailedText=json.dumps(status, indent=2))
             logging.info(msg)


### PR DESCRIPTION
Small enhancement; can save the user one annoying click.

- Added MONAILabel property MONAILabel/autoOpenSegmentEditor to control if user wants to automatically open segment editor after next sample was fetched
- Added logic to initSample() to activate Slicer's segment editor automatically after next sample was fetched