### PR TITLE
Add collapsible segment editor widget to Slicer extension

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -136,17 +136,6 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
-        askForUserNameCheckBox = qt.QCheckBox()
-        askForUserNameCheckBox.checked = False
-        askForUserNameCheckBox.toolTip = "Enable this option to ask for the user name every time the MONAILabel extension is loaded for the first time"
-        groupLayout.addRow("Ask For User Name:", askForUserNameCheckBox)
-        parent.registerProperty(
-            "MONAILabel/askForUserName",
-            ctk.ctkBooleanMapper(askForUserNameCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
-            "valueAsInt",
-            str(qt.SIGNAL("valueAsIntChanged(int)")),
-        )
-
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -319,7 +308,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.updateServerUrlGUIFromSettings()
         # self.onClickFetchInfo()
 
-        if slicer.util.settingsValue("MONAILabel/askForUserName", None):
+        if slicer.util.settingsValue("MONAILabel/askForUserName", False, converter=slicer.util.toBool):
             text = qt.QInputDialog().getText(
                 self.parent,
                 "User Name",

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -125,19 +125,6 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
-        autoOpenSegmentEditorCheckBox = qt.QCheckBox()
-        autoOpenSegmentEditorCheckBox.checked = False
-        autoOpenSegmentEditorCheckBox.toolTip = (
-            "Enable this option to automatically open segment editor after Next Sample was fetched"
-        )
-        groupLayout.addRow("Auto-Open Segment Editor:", autoOpenSegmentEditorCheckBox)
-        parent.registerProperty(
-            "MONAILabel/autoOpenSegmentEditor",
-            ctk.ctkBooleanMapper(autoOpenSegmentEditorCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
-            "valueAsInt",
-            str(qt.SIGNAL("valueAsIntChanged(int)")),
-        )
-
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -1144,10 +1131,6 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         self.ui.segmentationModelSelector.currentText = name
                         self.onClickSegmentation()
                         return
-
-        # Check if user wants to automatically open segment editor after next sample was fetched
-        if slicer.util.settingsValue("MONAILabel/autoOpenSegmentEditor", False, converter=slicer.util.toBool):
-            slicer.util.selectModule("SegmentEditor")
 
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -301,6 +301,11 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.scribblesCollapsibleButton.setEnabled(False)
         self.ui.scribblesCollapsibleButton.collapsed = True
 
+        # embedded segment editor
+        self.ui.embeddedSegmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        self.ui.embeddedSegmentEditorWidget.setSegmentationNodeSelectorVisible(False)
+        self.ui.embeddedSegmentEditorWidget.setMasterVolumeNodeSelectorVisible(False)
+
         self.initializeParameterNode()
         self.updateServerUrlGUIFromSettings()
         # self.onClickFetchInfo()
@@ -558,6 +563,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.ui.dgUpdateCheckBox.setEnabled(self.ui.deepgrowModelSelector.currentText and self._segmentNode)
         self.ui.dgUpdateButton.setEnabled(self.ui.deepgrowModelSelector.currentText and self._segmentNode)
+
+        self.ui.embeddedSegmentEditorWidget.setMRMLSegmentEditorNode(slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentEditorNode"))
 
         # All the GUI updates are done
         self._updatingGUIFromParameterNode = False

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -125,6 +125,17 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        askForUserNameCheckBox = qt.QCheckBox()
+        askForUserNameCheckBox.checked = False
+        askForUserNameCheckBox.toolTip = "Enable this option to ask for the user name every time the MONAILabel extension is loaded for the first time"
+        groupLayout.addRow("Ask For User Name:", askForUserNameCheckBox)
+        parent.registerProperty(
+            "MONAILabel/askForUserName",
+            ctk.ctkBooleanMapper(askForUserNameCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -296,6 +307,18 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
         self.updateServerUrlGUIFromSettings()
         # self.onClickFetchInfo()
+
+        if slicer.util.settingsValue("MONAILabel/askForUserName", None):
+            text = qt.QInputDialog().getText(
+                self.parent,
+                "User Name",
+                "Please enter your name:",
+                qt.QLineEdit.Normal,
+                slicer.util.settingsValue("MONAILabel/clientId", None),
+            )
+            if text:
+                settings = qt.QSettings()
+                settings.setValue("MONAILabel/clientId", text)
 
     def cleanup(self):
         self.removeObservers()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -125,17 +125,6 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
-        askForUserNameCheckBox = qt.QCheckBox()
-        askForUserNameCheckBox.checked = False
-        askForUserNameCheckBox.toolTip = "Enable this option to ask for the user name every time the MONAILabel extension is loaded for the first time"
-        groupLayout.addRow("Ask For User Name:", askForUserNameCheckBox)
-        parent.registerProperty(
-            "MONAILabel/askForUserName",
-            ctk.ctkBooleanMapper(askForUserNameCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
-            "valueAsInt",
-            str(qt.SIGNAL("valueAsIntChanged(int)")),
-        )
-
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -307,18 +296,6 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
         self.updateServerUrlGUIFromSettings()
         # self.onClickFetchInfo()
-
-        if slicer.util.settingsValue("MONAILabel/askForUserName", None):
-            text = qt.QInputDialog().getText(
-                self.parent,
-                "User Name",
-                "Please enter your name:",
-                qt.QLineEdit.Normal,
-                slicer.util.settingsValue("MONAILabel/clientId", None),
-            )
-            if text:
-                settings = qt.QSettings()
-                settings.setValue("MONAILabel/clientId", text)
 
     def cleanup(self):
         self.removeObservers()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -426,6 +426,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.inputSelector.clear()
         for v in self._volumeNodes:
             self.ui.inputSelector.addItem(v.GetName())
+            self.ui.inputSelector.setToolTip(self.current_sample.get("name", "") if self.current_sample else "")
         if self._volumeNode:
             self.ui.inputSelector.setCurrentIndex(self.ui.inputSelector.findText(self._volumeNode.GetName()))
         self.ui.inputSelector.setEnabled(False)  # Allow only one active scene

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -551,7 +551,9 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.dgUpdateCheckBox.setEnabled(self.ui.deepgrowModelSelector.currentText and self._segmentNode)
         self.ui.dgUpdateButton.setEnabled(self.ui.deepgrowModelSelector.currentText and self._segmentNode)
 
-        self.ui.embeddedSegmentEditorWidget.setMRMLSegmentEditorNode(slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentEditorNode"))
+        self.ui.embeddedSegmentEditorWidget.setMRMLSegmentEditorNode(
+            slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentEditorNode")
+        )
 
         # All the GUI updates are done
         self._updatingGUIFromParameterNode = False

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -292,6 +292,9 @@
      <property name="collapsed">
       <bool>true</bool>
      </property>
+     <property name="collapsedHeight">
+      <number>9</number>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="qMRMLSegmentEditorWidget" name="embeddedSegmentEditorWidget">
@@ -300,44 +303,6 @@
         </property>
         <property name="maximumNumberOfUndoStates">
          <number>10</number>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="toolsCollapsibleButton">
-     <property name="text">
-      <string>Tools</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <property name="collapsedHeight">
-      <number>9</number>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <item row="2" column="1">
-       <widget class="ctkPathLineEdit" name="labelPathLineEdit"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="text">
-         <string>Import Label:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QPushButton" name="importLabelButton">
-        <property name="text">
-         <string/>
         </property>
        </widget>
       </item>
@@ -690,6 +655,44 @@
          </layout>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="toolsCollapsibleButton">
+     <property name="text">
+      <string>Tools</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="collapsedHeight">
+      <number>9</number>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item row="2" column="1">
+       <widget class="ctkPathLineEdit" name="labelPathLineEdit"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Import Label:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QPushButton" name="importLabelButton">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>867</height>
+    <height>1055</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -152,7 +152,7 @@
          <bool>true</bool>
         </attribute>
         <attribute name="verticalHeaderDefaultSectionSize">
-         <number>20</number>
+         <number>21</number>
         </attribute>
         <column/>
         <column/>
@@ -280,6 +280,28 @@
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="QComboBox" name="strategyBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="seCollapsibleButton">
+     <property name="text">
+      <string>Segment Editor</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="qMRMLSegmentEditorWidget" name="embeddedSegmentEditorWidget">
+        <property name="autoShowMasterVolumeNode">
+         <bool>true</bool>
+        </property>
+        <property name="maximumNumberOfUndoStates">
+         <number>10</number>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -720,6 +742,11 @@
    <class>qSlicerMarkupsPlaceWidget</class>
    <extends>qSlicerWidget</extends>
    <header>qSlicerMarkupsPlaceWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSegmentEditorWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSegmentEditorWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
- added collapsible qMRMLSegmentEditorWidget below "active learning" section
- default status is collapsed
- removed now unnecessary user setting auto-open segment editor 

(see also discussion in PR #567)