### PR TITLE
feat: Allow networks to be loaded on CPU if CUDA is not available

### DIFF
--- a/monailabel/interfaces/tasks/infer.py
+++ b/monailabel/interfaces/tasks/infer.py
@@ -321,7 +321,7 @@ class InferTask:
                     if torch.cuda.is_available():
                         checkpoint = torch.load(path)
                     else:
-                        checkpoint = torch.load(path,  map_location=torch.device('cpu'))
+                        checkpoint = torch.load(path, map_location=torch.device("cpu"))
 
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
@@ -330,7 +330,7 @@ class InferTask:
                 if torch.cuda.is_available():
                     network = torch.jit.load(path)
                 else:
-                    network = torch.jit.load(path,  map_location=torch.device('cpu'))
+                    network = torch.jit.load(path, map_location=torch.device("cpu"))
 
             if device == "cuda":
                 network = network.cuda()
@@ -354,8 +354,8 @@ class InferTask:
         inferer = self.inferer()
         logger.info("Running Inferer:: {}".format(inferer.__class__.__name__))
 
-        if device == 'cuda' and torch.cuda.is_available() == False:
-            device = 'cpu'
+        if device == "cuda" and not torch.cuda.is_available():
+            device = "cpu"
 
         network = self._get_network(device)
         if network:
@@ -364,7 +364,7 @@ class InferTask:
             inputs = inputs[None] if convert_to_batch else inputs
             if device == "cuda":
                 inputs = inputs.cuda()
-            
+
             with torch.no_grad():
                 outputs = inferer(inputs, network)
             if device == "cuda":


### PR DESCRIPTION
Hi everyone,

I wanted to try MONAI Label on my laptop but it does not have a GPU with CUDA. It's not fast, but it seems to work. I only changed it for inference right now, but I see torch.load and torch.jit.load in the epistemic.py and tta.py inside tasks/scoring as well.

I don't have an NVIDIA GPU around to check if this breaks anything for anyone else though.

Thoughts?