### PR TITLE
Support overlapping segments in Slicer extension

### DIFF
--- a/.azure/azure-build-test-gpu-pipeline.yml
+++ b/.azure/azure-build-test-gpu-pipeline.yml
@@ -10,6 +10,13 @@ stages:
         #container: projectmonai/monai:latest
         steps:
           - script: |
+              sudo killall apt apt-get | echo killing existing apt
+              sudo rm -rf /var/lib/apt/lists/lock
+              sudo rm -rf /var/cache/apt/archives/lock
+              sudo rm -rf /var/lib/dpkg/lock
+              sudo dpkg --configure -a
+              sudo apt-get update --fix-missing -y
+              sudo apt-get install -f -y
               sudo apt update && sudo apt install -y python3-pip python-is-python3
               python3 -m pip install --upgrade pip wheel
               python3 -m pip install -r requirements-dev.txt
@@ -53,6 +60,13 @@ stages:
         #container: projectmonai/monai:latest
         steps:
           - script: |
+              sudo killall apt apt-get | echo killing existing apt
+              sudo rm -rf /var/lib/apt/lists/lock
+              sudo rm -rf /var/cache/apt/archives/lock
+              sudo rm -rf /var/lib/dpkg/lock
+              sudo dpkg --configure -a
+              sudo apt-get update --fix-missing -y
+              sudo apt-get install -f -y
               sudo apt update && sudo apt install -y python3-pip python-is-python3 npm
               sudo npm install --global yarn
               python3 -m pip install --user --upgrade pip setuptools wheel

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'Project-MONAI/MONAILabel'
     runs-on: ubuntu-latest
     env:
-      DEV_RELEASE_VERSION: 0.3
+      DEV_RELEASE_VERSION: 0.4
     steps:
       - uses: actions/checkout@v2
         with:
@@ -76,5 +76,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_WEEKLY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ LABEL maintainer="monai.contact@gmail.com"
 ADD . /opt/monailabel/
 RUN apt update -y && apt install npm -y && npm install --global yarn
 RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel twine \
-    && export BUILD_OHIF=true \
     && cd /opt/monailabel \
     && python setup.py sdist
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 Prerequisites
 ---------------
-MONAI Label supports following OS with GPU/CUDA enabled.
+MONAI Label supports both Ubuntu and Windows OS with GPU/CUDA enabled.
 
 Windows
 ********

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,10 +4,8 @@ Installation
 
 Prerequisites
 ---------------
-MONAI Label supports both Ubuntu and Windows OS with GPU/CUDA enabled.
+MONAI Label supports both **Ubuntu** and **Windows** OS with GPU/CUDA enabled.
 
-Windows
-********
 Make sure you have python 3.x version environment with PyTorch and CUDA installed.
 
 - Install `Python <https://www.python.org/downloads/>`_
@@ -97,7 +95,7 @@ Starting Server
 You can start server using *monailabel* CLI
 ::
 
-  monailabel start_server --app apps\deepedit --studies datasets\Task09_Spleen\imagesTr
+  monailabel start_server --app apps/deepedit --studies datasets/Task09_Spleen/imagesTr
 
 
 .. note::
@@ -117,14 +115,14 @@ Deploying MONAI Label server for production use is out of project scope.  Howeve
 ::
 
   # dryrun the MONAI Label CLI for pre-init and dump the env variables to .env or env.bat
-  monailabel start_server --app apps\deepedit --studies datasets\Task09_Spleen\imagesTr --host 0.0.0.0 --port 8000 --dryrun
+  monailabel start_server --app apps/deepedit --studies datasets/Task09_Spleen/imagesTr --host 0.0.0.0 --port 8000 --dryrun
 
   # Linux/Ubuntu
   source .env
   uvicorn monailabel.app:app \
     --host 0.0.0.0 \
     --port 8000 \
-    --log-config apps\deepedit\logs\logging.json \
+    --log-config apps/deepedit/logs/logging.json \
     --no-access-log
 
 
@@ -155,7 +153,16 @@ MONAI Label comes with `pre-built plugin <https://github.com/Project-MONAI/MONAI
 
 ::
 
-  monailabel start_server --app apps\deepedit --studies http://127.0.0.1:8042/dicom-web
+  monailabel start_server --app apps/deepedit --studies http://127.0.0.1:8042/dicom-web
+
+
+If you have authentication set for dicom-web then you can pass the credentials using environment `variables <https://github.com/Project-MONAI/MONAILabel/blob/main/monailabel/config.py>`_ while running the server.
+
+::
+
+  export MONAI_LABEL_DICOMWEB_USERNAME=xyz
+  export MONAI_LABEL_DICOMWEB_PASSWORD=abc
+  monailabel start_server --app apps/deepedit --studies http://127.0.0.1:8042/dicom-web
 
 
 .. note::

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -3,7 +3,7 @@ Modules Overview
 ================
 
 MONAI Label aims to allow researchers to build labeling applications in a serverless way.
-This means that MONAI Label applications are always ready-to-deploy via MONAL Label server.
+This means that MONAI Label applications are always ready-to-deploy via MONAI Label server.
 
 To develop a new MONAI labeling app, developers must inherit the :py:class:`~monailabel.interfaces.MONAILabelApp` interface
 and implement the methods in the interface that are relevant to their application. Typically a
@@ -20,7 +20,7 @@ employs
 - | two inferencing tasks, namely :py:class:`MyInfer` which is a custom implementation of :py:class:`~monailabel.interfaces.tasks.InferTask`, 
   | and :py:class:`~monailabel.utils.infer.deepgrow_2d.InferDeepGrow2D` which is a ready-to-use utility included with MONAI Label,
 - one training task, :py:class:`TrainDeepGrow` which is an extension of the :py:class:`~monailabel.utils.train.base_train.BasicTrainTask` utility,
-- | and two next image selection strategies, :py:class:`~monailabel.interfaces.utils.activelearning.Random` included with MONAL Label which allow 
+- | and two next image selection strategies, :py:class:`~monailabel.interfaces.utils.activelearning.Random` included with MONAI Label which allow 
   | the user to select the next image at random, and :py:class:`MyStrategy` which implements the interface 
   | :py:class:`~monailabel.interfaces.Strategy` which the end user may select as a custom alternative for next image selection
 

--- a/monailabel/datastore/local.py
+++ b/monailabel/datastore/local.py
@@ -583,7 +583,7 @@ class LocalDatastore(Datastore):
                 name = self._filename(label_id, label_ext)
                 label_info = {
                     "ts": int(time.time()),
-                    "checksum": file_checksum(os.path.join(self._datastore.image_path(), name)),
+                    "checksum": file_checksum(os.path.join(self._datastore.label_path(), name)),
                     "name": name,
                 }
 

--- a/monailabel/datastore/local.py
+++ b/monailabel/datastore/local.py
@@ -583,7 +583,7 @@ class LocalDatastore(Datastore):
                 name = self._filename(label_id, label_ext)
                 label_info = {
                     "ts": int(time.time()),
-                    "checksum": file_checksum(os.path.join(self._datastore.label_path(), name)),
+                    "checksum": file_checksum(os.path.join(self._datastore.label_path(tag), name)),
                     "name": name,
                 }
 

--- a/monailabel/interfaces/tasks/infer.py
+++ b/monailabel/interfaces/tasks/infer.py
@@ -67,6 +67,7 @@ class InferTask:
         output_label_key="pred",
         output_json_key="result",
         config=None,
+        load_strict=False,
     ):
         """
         :param path: Model File Path. Supports multiple paths to support versions (Last item will be picked as latest)
@@ -79,6 +80,7 @@ class InferTask:
         :param output_label_key: Output key for storing result/label of inference
         :param output_json_key: Output key for storing result/label of inference
         :param config: K,V pairs to be part of user config
+        :param load_strict: Load model in strict mode
         """
         self.path = path
         self.network = network
@@ -90,6 +92,7 @@ class InferTask:
         self.input_key = input_key
         self.output_label_key = output_label_key
         self.output_json_key = output_json_key
+        self.load_strict = load_strict
 
         self._networks: Dict = {}
         self._config = {
@@ -316,7 +319,7 @@ class InferTask:
                 if path:
                     checkpoint = torch.load(path)
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
-                    network.load_state_dict(model_state_dict)
+                    network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:
                 network = torch.jit.load(path)
 

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -138,6 +138,17 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        askForUserNameCheckBox = qt.QCheckBox()
+        askForUserNameCheckBox.checked = False
+        askForUserNameCheckBox.toolTip = "Enable this option to ask for the user name every time the MONAILabel extension is loaded for the first time"
+        groupLayout.addRow("Ask For User Name:", askForUserNameCheckBox)
+        parent.registerProperty(
+            "MONAILabel/askForUserName",
+            ctk.ctkBooleanMapper(askForUserNameCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
@@ -304,6 +315,18 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
         self.updateServerUrlGUIFromSettings()
         # self.onClickFetchInfo()
+
+        if slicer.util.settingsValue("MONAILabel/askForUserName", None):
+            text = qt.QInputDialog().getText(
+                self.parent,
+                "User Name",
+                "Please enter your name:",
+                qt.QLineEdit.Normal,
+                slicer.util.settingsValue("MONAILabel/clientId", None),
+            )
+            if text:
+                settings = qt.QSettings()
+                settings.setValue("MONAILabel/clientId", text)
 
     def cleanup(self):
         self.removeObservers()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1202,10 +1202,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
             qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
             segmentationNode = self._segmentNode
-            labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
-            slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
-                segmentationNode, labelmapVolumeNode, self._volumeNode
-            )
+            #labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+            #slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
+                #segmentationNode, labelmapVolumeNode, self._volumeNode
+            #)
 
             segmentation = segmentationNode.GetSegmentation()
             totalSegments = segmentation.GetNumberOfSegments()
@@ -1225,7 +1225,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            slicer.util.saveNode(labelmapVolumeNode, label_in)
+            #slicer.util.saveNode(labelmapVolumeNode, label_in)
+            slicer.util.saveNode(segmentationNode, label_in)
             self.reportProgress(30)
 
             self.updateServerSettings()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -426,6 +426,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.inputSelector.clear()
         for v in self._volumeNodes:
             self.ui.inputSelector.addItem(v.GetName())
+            self.ui.inputSelector.setToolTip(self.current_sample.get("name", "") if self.current_sample else "")
         if self._volumeNode:
             self.ui.inputSelector.setCurrentIndex(self.ui.inputSelector.findText(self._volumeNode.GetName()))
         self.ui.inputSelector.setEnabled(False)  # Allow only one active scene

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -160,8 +160,25 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        allowOverlapCheckBox = qt.QCheckBox()
+        allowOverlapCheckBox.checked = False
+        allowOverlapCheckBox.toolTip = "Enable this option to allow overlapping segmentations"
+        groupLayout.addRow("Allow Overlapping Segmentations:", allowOverlapCheckBox)
+        parent.registerProperty(
+            "MONAILabel/allowOverlappingSegments",
+            ctk.ctkBooleanMapper(allowOverlapCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+        allowOverlapCheckBox.connect("toggled(bool)", self.onUpdateAllowOverlap)
+
         vBoxLayout.addWidget(groupBox)
         vBoxLayout.addStretch(1)
+
+    def onUpdateAllowOverlap(self):
+        if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool):
+            if slicer.util.settingsValue("MONAILabel/fileExtension", None) != '.seg.nrrd':
+                slicer.util.warningDisplay("Overlapping segmentations are only availabel with the '.seg.nrrd' file extension!")
 
 
 class MONAILabelSettingsPanel(ctk.ctkSettingsPanel):
@@ -1146,6 +1163,11 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         segmentEditorWidget.setSegmentationNode(self._segmentNode)
         segmentEditorWidget.setMasterVolumeNode(self._volumeNode)
 
+        # check if user allows overlapping segments
+        if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", False, converter=slicer.util.toBool):
+            # set segment editor to allow overlaps
+            slicer.util.getNodesByClass("vtkMRMLSegmentEditorNode")[0].SetOverwriteMode(2)
+        
         if self.info.get("labels"):
             self.updateSegmentationMask(None, self.info.get("labels"))
 
@@ -1266,7 +1288,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            slicer.util.saveNode(labelmapVolumeNode, label_in)
+            if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool) and slicer.util.settingsValue("MONAILabel/fileExtension", None) == '.seg.nrrd':
+                slicer.util.saveNode(segmentationNode, label_in)
+            else:
+                slicer.util.saveNode(labelmapVolumeNode, label_in)
             self.reportProgress(30)
 
             self.updateServerSettings()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -136,17 +136,6 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
-        developerModeCheckBox = qt.QCheckBox()
-        developerModeCheckBox.checked = False
-        developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
-        groupLayout.addRow("Developer Mode:", developerModeCheckBox)
-        parent.registerProperty(
-            "MONAILabel/developerMode",
-            ctk.ctkBooleanMapper(developerModeCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
-            "valueAsInt",
-            str(qt.SIGNAL("valueAsIntChanged(int)")),
-        )
-
         allowOverlapCheckBox = qt.QCheckBox()
         allowOverlapCheckBox.checked = False
         allowOverlapCheckBox.toolTip = "Enable this option to allow overlapping segmentations"
@@ -159,13 +148,26 @@ class _ui_MONAILabelSettingsPanel(object):
         )
         allowOverlapCheckBox.connect("toggled(bool)", self.onUpdateAllowOverlap)
 
+        developerModeCheckBox = qt.QCheckBox()
+        developerModeCheckBox.checked = False
+        developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."
+        groupLayout.addRow("Developer Mode:", developerModeCheckBox)
+        parent.registerProperty(
+            "MONAILabel/developerMode",
+            ctk.ctkBooleanMapper(developerModeCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+
         vBoxLayout.addWidget(groupBox)
         vBoxLayout.addStretch(1)
 
     def onUpdateAllowOverlap(self):
         if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool):
-            if slicer.util.settingsValue("MONAILabel/fileExtension", None) != '.seg.nrrd':
-                slicer.util.warningDisplay("Overlapping segmentations are only availabel with the '.seg.nrrd' file extension!")
+            if slicer.util.settingsValue("MONAILabel/fileExtension", None) != ".seg.nrrd":
+                slicer.util.warningDisplay(
+                    "Overlapping segmentations are only availabel with the '.seg.nrrd' file extension! Consider changing MONAILabel file extension."
+                )
 
 
 class MONAILabelSettingsPanel(ctk.ctkSettingsPanel):
@@ -1163,7 +1165,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", False, converter=slicer.util.toBool):
             # set segment editor to allow overlaps
             slicer.util.getNodesByClass("vtkMRMLSegmentEditorNode")[0].SetOverwriteMode(2)
-        
+
         if self.info.get("labels"):
             self.updateSegmentationMask(None, self.info.get("labels"))
 
@@ -1280,7 +1282,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool) and slicer.util.settingsValue("MONAILabel/fileExtension", None) == '.seg.nrrd':
+            if (
+                slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool)
+                and slicer.util.settingsValue("MONAILabel/fileExtension", self.file_ext) == ".seg.nrrd"
+            ):
                 slicer.util.saveNode(segmentationNode, label_in)
             else:
                 slicer.util.saveNode(labelmapVolumeNode, label_in)

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>867</height>
+    <height>1055</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -152,7 +152,7 @@
          <bool>true</bool>
         </attribute>
         <attribute name="verticalHeaderDefaultSectionSize">
-         <number>20</number>
+         <number>21</number>
         </attribute>
         <column/>
         <column/>
@@ -285,9 +285,9 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="toolsCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="seCollapsibleButton">
      <property name="text">
-      <string>Tools</string>
+      <string>Segment Editor</string>
      </property>
      <property name="collapsed">
       <bool>true</bool>
@@ -295,27 +295,14 @@
      <property name="collapsedHeight">
       <number>9</number>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <item row="2" column="1">
-       <widget class="ctkPathLineEdit" name="labelPathLineEdit"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="text">
-         <string>Import Label:</string>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="qMRMLSegmentEditorWidget" name="embeddedSegmentEditorWidget">
+        <property name="autoShowMasterVolumeNode">
+         <bool>true</bool>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QPushButton" name="importLabelButton">
-        <property name="text">
-         <string/>
+        <property name="maximumNumberOfUndoStates">
+         <number>10</number>
         </property>
        </widget>
       </item>
@@ -673,6 +660,44 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="toolsCollapsibleButton">
+     <property name="text">
+      <string>Tools</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="collapsedHeight">
+      <number>9</number>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item row="2" column="1">
+       <widget class="ctkPathLineEdit" name="labelPathLineEdit"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Import Label:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QPushButton" name="importLabelButton">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -720,6 +745,11 @@
    <class>qSlicerMarkupsPlaceWidget</class>
    <extends>qSlicerWidget</extends>
    <header>qSlicerMarkupsPlaceWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSegmentEditorWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSegmentEditorWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==0.6.0
 fastapi==0.65.2
-monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]==0.8.0
+monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]==0.8.*
 pyyaml==5.4.1
 python-multipart==0.0.5
 requests-toolbelt==0.9.1

--- a/sample-apps/deepedit/main.py
+++ b/sample-apps/deepedit/main.py
@@ -84,7 +84,7 @@ class MyApp(MONAILabelApp):
             }
             self.network = DynUNet(**network_params)
             self.network_with_dropout = DynUNet(**network_params, dropout=0.2)
-            self.find_unused_parameters = True
+            self.find_unused_parameters = False
 
         self.model_dir = os.path.join(app_dir, "model")
         self.pretrained_model = os.path.join(self.model_dir, f"pretrained_{network}.pt")

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
 install_requires =
     aiofiles==0.6.0
     fastapi==0.65.2
-    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]==0.8.0
+    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]==0.8.*
     pyyaml==5.4.1
     python-multipart==0.0.5
     requests-toolbelt==0.9.1


### PR DESCRIPTION
Fix for issue #565.

- introduce MONAILabel setting "allowOverlappingSegments"
  - default status is False
  - if set to True and MONAILabel file extension is ".seg.nrrd" segments are directly saved from the segmentation node which prevents flattening of overlapping segments/information loss
  - if set to False segments are saved from a labelmap node (unchanged prior implementation)