### PR TITLE
Support overlapping segments in Slicer extension

### DIFF
--- a/monailabel/datastore/local.py
+++ b/monailabel/datastore/local.py
@@ -583,7 +583,7 @@ class LocalDatastore(Datastore):
                 name = self._filename(label_id, label_ext)
                 label_info = {
                     "ts": int(time.time()),
-                    "checksum": file_checksum(os.path.join(self._datastore.image_path(), name)),
+                    "checksum": file_checksum(os.path.join(self._datastore.label_path(), name)),
                     "name": name,
                 }
 

--- a/monailabel/datastore/local.py
+++ b/monailabel/datastore/local.py
@@ -583,7 +583,7 @@ class LocalDatastore(Datastore):
                 name = self._filename(label_id, label_ext)
                 label_info = {
                     "ts": int(time.time()),
-                    "checksum": file_checksum(os.path.join(self._datastore.label_path(), name)),
+                    "checksum": file_checksum(os.path.join(self._datastore.label_path(tag), name)),
                     "name": name,
                 }
 

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1202,10 +1202,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
             qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
             segmentationNode = self._segmentNode
-            labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
-            slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
-                segmentationNode, labelmapVolumeNode, self._volumeNode
-            )
+            #labelmapVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+            #slicer.modules.segmentations.logic().ExportVisibleSegmentsToLabelmapNode(
+                #segmentationNode, labelmapVolumeNode, self._volumeNode
+            #)
 
             segmentation = segmentationNode.GetSegmentation()
             totalSegments = segmentation.GetNumberOfSegments()
@@ -1225,7 +1225,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             label_in = tempfile.NamedTemporaryFile(suffix=self.file_ext, dir=self.tmpdir).name
             self.reportProgress(5)
 
-            slicer.util.saveNode(labelmapVolumeNode, label_in)
+            #slicer.util.saveNode(labelmapVolumeNode, label_in)
+            slicer.util.saveNode(segmentationNode, label_in)
             self.reportProgress(30)
 
             self.updateServerSettings()

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -136,6 +136,18 @@ class _ui_MONAILabelSettingsPanel(object):
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        allowOverlapCheckBox = qt.QCheckBox()
+        allowOverlapCheckBox.checked = False
+        allowOverlapCheckBox.toolTip = "Enable this option to allow overlapping segmentations"
+        groupLayout.addRow("Allow Overlapping Segmentations:", allowOverlapCheckBox)
+        parent.registerProperty(
+            "MONAILabel/allowOverlappingSegments",
+            ctk.ctkBooleanMapper(allowOverlapCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+        allowOverlapCheckBox.connect("toggled(bool)", self.onUpdateAllowOverlap)
+
         developerModeCheckBox = qt.QCheckBox()
         developerModeCheckBox.checked = False
         developerModeCheckBox.toolTip = "Enable this option to find options tab etc..."

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -162,12 +162,13 @@ class _ui_MONAILabelSettingsPanel(object):
         vBoxLayout.addWidget(groupBox)
         vBoxLayout.addStretch(1)
 
-        def onUpdateAllowOverlap(self):
-            if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool):
-                if slicer.util.settingsValue("MONAILabel/fileExtension", None) != ".seg.nrrd":
-                    slicer.util.warningDisplay(
-                        "Overlapping segmentations are only availabel with the '.seg.nrrd' file extension! Consider changing MONAILabel file extension."
-                    )
+    def onUpdateAllowOverlap(self):
+        if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool):
+            if slicer.util.settingsValue("MONAILabel/fileExtension", None) != ".seg.nrrd":
+                slicer.util.warningDisplay(
+                    "Overlapping segmentations are only availabel with the '.seg.nrrd' file extension! Consider changing MONAILabel file extension."
+                )
+
 
 class MONAILabelSettingsPanel(ctk.ctkSettingsPanel):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fix for issue #565.

- introduce MONAILabel setting "allowOverlappingSegments"
  - default status is False
  - if set to True and MONAILabel file extension is ".seg.nrrd" segments are directly saved from the segmentation node which prevents flattening of overlapping segments/information loss
  - if set to False segments are saved from a labelmap node (unchanged prior implementation)