### PR TITLE
Fixes for DICOM Web (to support lightweight/static dicom interface through aws)

### DIFF
--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     MONAI_LABEL_QIDO_PREFIX: str = ""
     MONAI_LABEL_WADO_PREFIX: str = ""
     MONAI_LABEL_STOW_PREFIX: str = ""
+    MONAI_LABEL_DICOMWEB_FETCH_BY_FRAME: bool = False
 
     MONAI_LABEL_DATASTORE_AUTO_RELOAD: bool = True
     MONAI_LABEL_DATASTORE_FILE_EXT: List[str] = ["*.nii.gz", "*.nii", "*.nrrd"]

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -30,7 +30,10 @@ logger = logging.getLogger(__name__)
 
 class DICOMwebClientX(DICOMwebClient):
     def _decode_multipart_message(self, response: requests.Response, stream: bool) -> Iterator[bytes]:
-        response.headers["content-type"] = "multipart/related"
+        content_type = response.headers["content-type"]
+        media_type, *ct_info = [ct.strip() for ct in content_type.split(";")]
+        if media_type.lower() != "multipart/related":
+            response.headers["content-type"] = "multipart/related"
         return super()._decode_multipart_message(response, stream)
 
 

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -13,8 +13,9 @@ import logging
 import os
 import pathlib
 import shutil
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+import requests
 from dicomweb_client import DICOMwebClient
 from dicomweb_client.api import load_json_dataset
 from expiringdict import ExpiringDict
@@ -27,17 +28,25 @@ from monailabel.interfaces.datastore import DefaultLabelTag
 logger = logging.getLogger(__name__)
 
 
+class DICOMwebClientX(DICOMwebClient):
+    def _decode_multipart_message(self, response: requests.Response, stream: bool) -> Iterator[bytes]:
+        response.headers["content-type"] = "multipart/related"
+        return super()._decode_multipart_message(response, stream)
+
+
 class DICOMWebDatastore(LocalDatastore):
-    def __init__(self, client: DICOMwebClient, cache_path: Optional[str] = None):
+    def __init__(self, client: DICOMwebClient, cache_path: Optional[str] = None, fetch_by_frame=False):
         self._client = client
         self._modality = "CT"
+        self._fetch_by_frame = fetch_by_frame
+
         uri_hash = hashlib.md5(self._client.base_url.encode("utf-8")).hexdigest()
         datastore_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path
             else os.path.join(pathlib.Path.home(), ".cache", "monailabel", uri_hash)
         )
-        logger.info(f"DICOMWeb Datastore (cache) Path: {datastore_path}")
+        logger.info(f"DICOMWeb Datastore (cache) Path: {datastore_path}; FetchByFrame: {fetch_by_frame}")
 
         self._stats_cache = ExpiringDict(max_len=100, max_age_seconds=30)
         super().__init__(datastore_path=datastore_path, auto_reload=True)
@@ -59,7 +68,7 @@ class DICOMWebDatastore(LocalDatastore):
         logger.info(f"Image Dir (cache): {image_dir}")
 
         if not os.path.exists(image_dir) or not os.listdir(image_dir):
-            dicom_web_download_series(None, image_id, image_dir, self._client)
+            dicom_web_download_series(None, image_id, image_dir, self._client, self._fetch_by_frame)
 
         image_nii_gz = os.path.realpath(os.path.join(self._datastore.image_path(), f"{image_id}.nii.gz"))
         if not os.path.exists(image_nii_gz):
@@ -77,7 +86,7 @@ class DICOMWebDatastore(LocalDatastore):
         logger.info(f"Label Dir (cache): {label_dir}")
 
         if not os.path.exists(label_dir) or not os.listdir(label_dir):
-            dicom_web_download_series(None, label_id, label_dir, self._client)
+            dicom_web_download_series(None, label_id, label_dir, self._client, self._fetch_by_frame)
 
         label_nii_gz = os.path.realpath(
             os.path.join(self._datastore.label_path(DefaultLabelTag.FINAL), f"{image_id}.nii.gz")
@@ -95,7 +104,7 @@ class DICOMWebDatastore(LocalDatastore):
 
         info = {"SeriesInstanceUID": series_id}
         for f in fields:
-            info[f] = str(meta[f].value)
+            info[f] = str(meta[f].value) if meta.get(f) else "UNK"
         return info
 
     def list_images(self) -> List[str]:
@@ -118,7 +127,7 @@ class DICOMWebDatastore(LocalDatastore):
                 image_series.append(str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value))
             else:
                 logger.warning(
-                    f"Label Ignored:: ReferencedSeriesSequence is NOT found in Label: {str(seg['SeriesInstanceUID'].value)}"
+                    f"Label Ignored:: ReferencedSeriesSequence is NOT found: {str(seg['SeriesInstanceUID'].value)}"
                 )
         return image_series
 
@@ -175,7 +184,7 @@ class DICOMWebDatastore(LocalDatastore):
             seg_meta = load_json_dataset(meta[0])
             if not seg_meta.get("ReferencedSeriesSequence"):
                 logger.warning(
-                    f"Label Ignored:: ReferencedSeriesSequence is NOT found in Label: {str(seg['SeriesInstanceUID'].value)}"
+                    f"Label Ignored:: ReferencedSeriesSequence is NOT found: {str(seg['SeriesInstanceUID'].value)}"
                 )
                 continue
 

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -114,7 +114,12 @@ class DICOMWebDatastore(LocalDatastore):
                 str(seg["StudyInstanceUID"].value), str(seg["SeriesInstanceUID"].value)
             )
             seg_meta = load_json_dataset(meta[0])
-            image_series.append(str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value))
+            if seg_meta.get("ReferencedSeriesSequence"):
+                image_series.append(str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value))
+            else:
+                logger.warning(
+                    f"Label Ignored:: ReferencedSeriesSequence is NOT found in Label: {str(seg['SeriesInstanceUID'].value)}"
+                )
         return image_series
 
     def get_unlabeled_images(self) -> List[str]:
@@ -168,6 +173,12 @@ class DICOMWebDatastore(LocalDatastore):
                 str(seg["StudyInstanceUID"].value), str(seg["SeriesInstanceUID"].value)
             )
             seg_meta = load_json_dataset(meta[0])
+            if not seg_meta.get("ReferencedSeriesSequence"):
+                logger.warning(
+                    f"Label Ignored:: ReferencedSeriesSequence is NOT found in Label: {str(seg['SeriesInstanceUID'].value)}"
+                )
+                continue
+
             image_labels.append(
                 {
                     "image": str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value),

--- a/monailabel/datastore/utils/dicom.py
+++ b/monailabel/datastore/utils/dicom.py
@@ -125,6 +125,7 @@ def dicom_web_upload_dcm(input_file, client: DICOMwebClient):
 
 if __name__ == "__main__":
     import shutil
+
     from monailabel.datastore.dicom import DICOMwebClientX
 
     client = DICOMwebClientX(

--- a/monailabel/datastore/utils/dicom.py
+++ b/monailabel/datastore/utils/dicom.py
@@ -11,6 +11,7 @@
 import logging
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from hashlib import md5
 
 from dicomweb_client import DICOMwebClient
@@ -60,7 +61,7 @@ def store_scu(input_file, host="127.0.0.1", port="4242", aet="MONAILABEL"):
     logger.info(f"Time to run STORE-SCU: {time.time() - start} (sec)")
 
 
-def dicom_web_download_series(study_id, series_id, save_dir, client: DICOMwebClient):
+def dicom_web_download_series(study_id, series_id, save_dir, client: DICOMwebClient, frame_fetch=False):
     start = time.time()
 
     # Limitation for DICOMWeb Client as it needs StudyInstanceUID to fetch series
@@ -69,11 +70,35 @@ def dicom_web_download_series(study_id, series_id, save_dir, client: DICOMwebCli
         study_id = str(meta["StudyInstanceUID"].value)
 
     os.makedirs(save_dir, exist_ok=True)
-    instances = client.retrieve_series(study_id, series_id)
-    for instance in instances:
-        instance_id = str(instance["SOPInstanceUID"].value)
-        file_name = os.path.join(save_dir, f"{instance_id}.dcm")
-        instance.save_as(file_name)
+    if not frame_fetch:
+        instances = client.retrieve_series(study_id, series_id)
+        for instance in instances:
+            instance_id = str(instance["SOPInstanceUID"].value)
+            file_name = os.path.join(save_dir, f"{instance_id}.dcm")
+            instance.save_as(file_name)
+    else:
+        # TODO:: This logic (combining meta+pixeldata) needs improvement
+        def save_from_frame(m):
+            d = load_json_dataset(m)
+            instance_id = str(d["SOPInstanceUID"].value)
+
+            # Hack to merge Info + RawData
+            d.is_little_endian = True
+            d.is_implicit_VR = True
+            d.PixelData = client.retrieve_instance_frames(
+                study_instance_uid=study_id,
+                series_instance_uid=series_id,
+                sop_instance_uid=instance_id,
+                frame_numbers=[1],
+            )[0]
+
+            file_name = os.path.join(save_dir, f"{instance_id}.dcm")
+            logger.info(f"++ Saved {file_name}")
+            d.save_as(file_name)
+
+        meta = client.retrieve_series_metadata(study_id, series_id)
+        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="DICOMFetch") as executor:
+            executor.map(save_from_frame, meta)
 
     logger.info(f"Time to download: {time.time() - start} (sec)")
 
@@ -96,3 +121,25 @@ def dicom_web_upload_dcm(input_file, client: DICOMwebClient):
 
     logger.info(f"Time to upload: {time.time() - start} (sec)")
     return series_id
+
+
+if __name__ == "__main__":
+    import shutil
+    from monailabel.datastore.dicom import DICOMwebClientX
+
+    client = DICOMwebClientX(
+        url="https://d1l7y4hjkxnyal.cloudfront.net",
+        session=None,
+        qido_url_prefix="output",
+        wado_url_prefix="output",
+        stow_url_prefix="output",
+    )
+
+    study_id = "1.2.840.113654.2.55.68425808326883186792123057288612355322"
+    series_id = "1.2.840.113654.2.55.257926562693607663865369179341285235858"
+
+    save_dir = "/local/sachi/Data/dicom"
+    shutil.rmtree(save_dir, ignore_errors=True)
+    os.makedirs(save_dir, exist_ok=True)
+
+    dicom_web_download_series(study_id, series_id, save_dir, client, True)

--- a/monailabel/endpoints/proxy.py
+++ b/monailabel/endpoints/proxy.py
@@ -24,8 +24,14 @@ async def proxy(path: str, response: Response):
     )
 
     async with httpx.AsyncClient(auth=auth) as client:
-        proxy_path = f"{settings.MONAI_LABEL_STUDIES.lstrip('/')}/{path}"
-        logger.debug(f"Proxy conneting to {proxy_path}")
+        server = f"{settings.MONAI_LABEL_STUDIES.rstrip('/')}"
+        # Assuming all prefix QIDO/WADO/STOW are same (proxy requests to support OHIF viewer)
+        if settings.MONAI_LABEL_WADO_PREFIX:
+            proxy_path = f"{server}/{settings.MONAI_LABEL_WADO_PREFIX}/{path}"
+        else:
+            proxy_path = f"{server}/{path}"
+
+        logger.debug(f"Proxy connecting to {proxy_path}")
         proxy = await client.get(proxy_path)
     response.body = proxy.content
     response.status_code = proxy.status_code

--- a/tests/unit/endpoints/test_dicomwebcache.py
+++ b/tests/unit/endpoints/test_dicomwebcache.py
@@ -62,9 +62,8 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def setUp(self) -> None:
         pass
 
-    @patch("monailabel.interfaces.app.DICOMwebClient")
+    @patch("monailabel.interfaces.app.DICOMwebClientX")
     def test_datastore_stats(self, dwc):
-
         cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
@@ -73,8 +72,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
         )
         dwc.return_value.load_json_dataset = lambda *args, **kwargs: retrieve_series(cache_path, *args, **kwargs)
 
-        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir)):
-
+        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir, False)):
             response = self.client.get("/datastore/?output=stats")
             self.assertEquals(response.status_code, 200)
 
@@ -87,10 +85,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
             self.assertEquals(label_tags["original"], 2)
             self.assertEquals(label_tags["final"], 1)
 
-    @patch("monailabel.interfaces.app.DICOMwebClient")
+    @patch("monailabel.interfaces.app.DICOMwebClientX")
     @patch("monailabel.datastore.dicom.dicom_web_download_series")
     def test_datastore_all(self, dicom_web_download_series, dwc):
-
         dicom_web_download_series.return_value = lambda *args: None
 
         cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
@@ -101,8 +98,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
         )
         dwc.return_value.load_json_dataset = lambda *args, **kwargs: retrieve_series(cache_path, *args, **kwargs)
 
-        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir)):
-
+        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir, False)):
             response = self.client.get("/datastore/?output=all")
             self.assertEquals(response.status_code, 200)
 
@@ -117,7 +113,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
                     ],
                 )
 
-    @patch("monailabel.interfaces.app.DICOMwebClient")
+    @patch("monailabel.interfaces.app.DICOMwebClientX")
     @patch("monailabel.datastore.dicom.dicom_web_download_series")
     def test_save_label(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
@@ -133,7 +129,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
         image_id = "1.2.826.0.1.3680043.8.274.1.1.8323329.686405.1629744173.656721"
         image_file = os.path.join(self.data_dir, f"{image_id}.nii.gz")
 
-        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir)):
+        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir, False)):
             test_tag = "test"
             with open(os.path.join(self.data_dir, "labels_to_upload", f"{image_id}.nii.gz"), "rb") as f:
                 response = self.client.put(
@@ -150,10 +146,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
             label_tags = res["label_tags"]
             self.assertEquals(label_tags[test_tag], 1)
 
-    @patch("monailabel.interfaces.app.DICOMwebClient")
+    @patch("monailabel.interfaces.app.DICOMwebClientX")
     @patch("monailabel.datastore.dicom.dicom_web_download_series")
     def test_datastore_train(self, dicom_web_download_series, dwc):
-
         dicom_web_download_series.return_value = lambda *args: None
 
         cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
@@ -164,8 +159,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
         )
         dwc.return_value.load_json_dataset = lambda *args, **kwargs: retrieve_series(cache_path, *args, **kwargs)
 
-        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir)):
-
+        with patch.object(DICOMWebDatastore.__init__, "__defaults__", (None, self.data_dir, False)):
             response = self.client.get("/datastore/?output=train")
             self.assertEquals(response.status_code, 200)
             res = response.json()


### PR DESCRIPTION
- Support AWS storage (lightweight dicomweb interface)
- Ignore labels if they don't have mapping ReferencedSeriesSequence
- Support other content type like simple oct stream instead of standard multipart for dicom response