### PR TITLE
use default font size and colour for options table

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -732,9 +732,6 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     else:
                         table.setItem(n, 3, qt.QTableWidgetItem(str(val) if val else ""))
 
-                    table.item(n, 0).setBackground(qt.QColor(220, 220, 220))
-                    table.item(n, 1).setBackground(qt.QColor(240, 240, 240))
-                    table.item(n, 2).setBackground(qt.QColor(250, 250, 250))
                     # print(f"{n} => {section} => {name} => {key} => {val}")
                     n = n + 1
 

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -134,11 +134,6 @@
       </property>
       <item row="0" column="0">
        <widget class="QTableWidget" name="configTable">
-        <property name="font">
-         <font>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
         <property name="autoFillBackground">
          <bool>true</bool>
         </property>


### PR DESCRIPTION
Setting the table colours to white makes them unreadable in dark mode (where text is also white). Also font size shouldn't be hard coded.