### PR TITLE
Add persistent dataset dir

### DIFF
--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -69,7 +69,7 @@ class Context:
         self.val_batch_size = None  # validation batch size
         self.device = None  # device on which training will run
         self.network = None  # network
-        self.dataset_type = "PersistentDataset"  # dataset type
+        self.dataset_type = "CacheDataset"  # dataset type
         self.dataloader_type = "ThreadDataLoader"  # dataloader type
         self.pretrained = False  # using pretrained model
         self.max_epochs = 1  # max epochs to run training

--- a/monailabel/utils/async_tasks/utils.py
+++ b/monailabel/utils/async_tasks/utils.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import os.path
+import random
 import subprocess
 import sys
 import uuid
@@ -42,7 +43,7 @@ def _task_func(task, method, callback=None):
     if method == "train":
         my_env["MONAI_LABEL_DATASTORE_AUTO_RELOAD"] = "false"
         my_env["MASTER_ADDR"] = "127.0.0.1"
-        my_env["MASTER_PORT"] = "1234"
+        my_env["MASTER_PORT"] = str(random.randint(1234, 1334))
 
     cmd = [
         sys.executable,


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAILabel/issues/609.

By default the persistent dataset dir is adjacent to the model checkpoint (typically at the base level of the sample app):

```
./sample-apps/deepedit_multilabel_VerSe/PersistentDir
```