### PR TITLE
Support verbose at command level + few other fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,5 @@
 name: docker
 on:
-  schedule:
-    - cron: "0 2 * * 0"  # 02:00 of every Sunday
-    inputs:
-      tag:
-        description: 'Tag name to publish'
-        required: false
-        default: 'latest'
-
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,13 @@
 name: docker
 on:
+  schedule:
+    - cron: "0 2 * * 0"  # 02:00 of every Sunday
+    inputs:
+      tag:
+        description: 'Tag name to publish'
+        required: false
+        default: 'latest'
+
   workflow_dispatch:
     inputs:
       tag:
@@ -35,50 +43,3 @@ jobs:
           docker push projectmonai/monailabel:${{ github.event.inputs.tag }}
           docker logout
           docker image prune -f
-
-  docker_test_dockerhub:
-    needs: docker_build
-    container:
-      image: docker://projectmonai/monailabel:${{ github.event.inputs.tag }}
-      options: "--shm-size=4g --ipc=host"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify
-        run: |
-          echo $CUDA_VISIBLE_DEVICES
-          python -c 'import monailabel; monailabel.print_config()'
-
-          mkdir -p cd /opt/monailabel
-          cd /opt/monailabel
-          monailabel apps --download --name deepedit --output apps
-          monailabel datasets --download --name Task04_Hippocampus --output datasets
-          monailabel start_server --app apps/deepedit --studies datasets/Task04_Hippocampus/imagesTr --host 127.0.0.1 --port 8000 &
-
-          wait_time=0
-          server_is_up=0
-          start_time_out=120
-
-          while [[ $wait_time -le ${start_time_out} ]]; do
-            code=$(curl --write-out "%{http_code}\n" -s "http://127.0.0.1:8000/" --output /dev/null)
-            if [ "${code}" == "200" ]; then
-              server_is_up=1
-              break
-            fi
-            sleep 5
-            wait_time=$((wait_time + 5))
-            echo "Waiting for MONAILabel to be up and running..."
-          done
-          echo ""
-
-          if [ "$server_is_up" == "1" ]; then
-            echo "MONAILabel server is up and running."
-          else
-            echo "Failed to start MONAILabel server. Exiting..."
-            exit 1
-          fi
-
-          curl http://127.0.0.1:8000/info/
-          kill -9 $(ps -ef | grep monailabel | grep -v grep | awk '{print $2}')
-        shell: bash
-        env:
-          QUICKTEST: True

--- a/monailabel/datastore/local.py
+++ b/monailabel/datastore/local.py
@@ -212,6 +212,10 @@ class LocalDatastore(Datastore):
 
     def _to_id(self, file: str) -> Tuple[str, str]:
         ext = file_ext(file)
+        extensions = [e.replace("*", "") for e in self._extensions]
+        for e in extensions:
+            if file.endswith(e):
+                ext = e
         id = file.replace(ext, "")
         return id, ext
 
@@ -403,7 +407,7 @@ class LocalDatastore(Datastore):
 
             image_info = image_info if image_info else {}
             image_info["ts"] = int(time.time())
-            image_info["checksum"] = file_checksum(dest)
+            # image_info["checksum"] = file_checksum(dest)
             image_info["name"] = name
 
             self._datastore.objects[image_id] = ImageLabelModel(image=DataModel(info=image_info, ext=image_ext))
@@ -553,7 +557,7 @@ class LocalDatastore(Datastore):
                 name = self._filename(image_id, image_ext)
                 image_info = {
                     "ts": int(time.time()),
-                    "checksum": file_checksum(os.path.join(self._datastore.image_path(), name)),
+                    # "checksum": file_checksum(os.path.join(self._datastore.image_path(), name)),
                     "name": name,
                 }
 

--- a/monailabel/deepedit/interaction.py
+++ b/monailabel/deepedit/interaction.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import Callable, Dict, Sequence, Union
 
 import numpy as np
@@ -90,8 +89,8 @@ class Interaction:
                 batchdata = list_data_collate(batchdata_list)
 
                 # first item in batch only
-                pos_click_sum += (batchdata_list[0]["is_pos"]) * 1
-                neg_click_sum += (batchdata_list[0]["is_neg"]) * 1
+                pos_click_sum += (batchdata_list[0].get("is_pos", 0)) * 1
+                neg_click_sum += (batchdata_list[0].get("is_neg", 0)) * 1
 
                 engine.fire_event(IterationEvents.INNER_ITERATION_COMPLETED)
 

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from datetime import timedelta
 from distutils.util import strtobool
-from typing import Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import requests
 import schedule
@@ -62,7 +62,7 @@ class MONAILabelApp:
         name: str = "",
         description: str = "",
         version: str = "2.0",
-        labels: Optional[Sequence[str]] = None,
+        labels: Union[Optional[Sequence[str]], Optional[Dict[Any, Any]]] = None,
     ):
         """
         Base Class for Any MONAI Label App

--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -37,7 +37,9 @@ class Main:
     def args_start_server(self, parser):
         parser.add_argument("-a", "--app", help="App Directory")
         parser.add_argument("-s", "--studies", help="Studies Directory")
-        parser.add_argument("-d", "--debug", action="store_true", help="Enable debug logs")
+        parser.add_argument(
+            "-v", "--verbose", default="INFO", type=str, choices=["DEBUG", "INFO", "WARNING", "ERROR"], help="Log Level"
+        )
 
         # --conf key1 value1 --conf key2 value2
         parser.add_argument(
@@ -236,7 +238,7 @@ class Main:
         self.start_server_validate_args(args)
         self.start_server_init_settings(args)
 
-        log_config = init_log_config(args.log_config, args.app, "app.log")
+        log_config = init_log_config(args.log_config, args.app, "app.log", args.verbose)
 
         if args.dryrun:
             return
@@ -247,10 +249,10 @@ class Main:
             app,
             host=args.host,
             port=args.port,
-            log_level="debug" if args.debug else "info",
+            log_level="info",
             log_config=log_config,
             use_colors=True,
-            access_log=args.debug,
+            access_log="info",
             ssl_keyfile=args.ssl_keyfile,
             ssl_certfile=args.ssl_certfile,
             ssl_keyfile_password=args.ssl_keyfile_password,

--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -509,6 +509,7 @@ class BasicTrainTask(TrainTask):
                         save_dict={self._model_dict_key: context.network},
                         save_key_metric=True,
                         key_metric_filename=self._key_metric_filename,
+                        n_saved=5,
                     )
                 )
 
@@ -540,6 +541,7 @@ class BasicTrainTask(TrainTask):
                     key_metric_filename=f"train_{self._key_metric_filename}"
                     if context.evaluator
                     else self._key_metric_filename,
+                    n_saved=5,
                 )
             )
 

--- a/monailabel/transform/writer.py
+++ b/monailabel/transform/writer.py
@@ -10,12 +10,13 @@
 # limitations under the License.
 
 import logging
-import pathlib
 import tempfile
 
 import itk
 import numpy as np
 from monai.data import write_nifti
+
+from monailabel.utils.others.generic import file_ext
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ class Writer:
         key_extension="result_extension",
         key_dtype="result_dtype",
         key_compress="result_compress",
+        key_write_to_file="result_write_to_file",
         meta_key_postfix="meta_dict",
         nibabel=False,
     ):
@@ -77,32 +79,39 @@ class Writer:
         self.key_extension = key_extension
         self.key_dtype = key_dtype
         self.key_compress = key_compress
+        self.key_write_to_file = key_write_to_file
         self.meta_key_postfix = meta_key_postfix
         self.nibabel = nibabel
 
     def __call__(self, data):
-        file_ext = "".join(pathlib.Path(data["image_path"]).suffixes)
+        ext = file_ext(data.get("image_path"))
         dtype = data.get(self.key_dtype, None)
         compress = data.get(self.key_compress, False)
-        file_ext = data.get(self.key_extension) if data.get(self.key_extension) else file_ext
-        logger.info("Result ext: {}".format(file_ext))
+        write_to_file = data.get(self.key_write_to_file, True)
+        ext = data.get(self.key_extension) if data.get(self.key_extension) else ext
+        logger.info("Result ext: {}".format(ext))
 
         image_np = data[self.label]
         meta_dict = data.get(f"{self.ref_image}_{self.meta_key_postfix}")
         affine = meta_dict.get("affine") if meta_dict else None
         logger.debug("Image: {}; Data Image: {}".format(image_np.shape, data[self.label].shape))
 
-        output_file = tempfile.NamedTemporaryFile(suffix=file_ext).name
-        logger.debug("Saving Image to: {}".format(output_file))
+        output_file = None
+        output_json = data.get(self.json, {})
+        if write_to_file:
+            output_file = tempfile.NamedTemporaryFile(suffix=ext).name
+            logger.debug("Saving Image to: {}".format(output_file))
 
-        # Issue with slicer:: https://discourse.itk.org/t/saving-non-orthogonal-volume-in-nifti-format/2760/22
-        if self.nibabel and file_ext.lower() in [".nii", ".nii.gz"]:
-            logger.debug("Using MONAI write_nifti...")
-            write_nifti(image_np, output_file, affine=affine, output_dtype=dtype)
+            # Issue with slicer:: https://discourse.itk.org/t/saving-non-orthogonal-volume-in-nifti-format/2760/22
+            if self.nibabel and ext.lower() in [".nii", ".nii.gz"]:
+                logger.debug("Using MONAI write_nifti...")
+                write_nifti(image_np, output_file, affine=affine, output_dtype=dtype)
+            else:
+                write_itk(image_np, output_file, affine, dtype, compress)
         else:
-            write_itk(image_np, output_file, affine, dtype, compress)
+            output_json[self.label] = image_np
 
-        return output_file, data.get(self.json, {})
+        return output_file, output_json
 
 
 class ClassificationWriter:

--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import hashlib
+import json
 import logging
 import mimetypes
 import os
@@ -23,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def file_ext(name) -> str:
-    return "".join(pathlib.Path(name).suffixes)
+    return "".join(pathlib.Path(name).suffixes) if name else ""
 
 
 def remove_file(path: str) -> None:
@@ -70,7 +71,7 @@ def run_command(command, args=None, plogger=None):
     return process.returncode
 
 
-def init_log_config(log_config, app_dir, log_file):
+def init_log_config(log_config, app_dir, log_file, root_level=None):
     if not log_config or not os.path.exists(log_config):
         default_log_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         default_config = os.path.realpath(os.path.join(default_log_dir, "logging.json"))
@@ -89,6 +90,14 @@ def init_log_config(log_config, app_dir, log_file):
 
         with open(log_config, "w") as f:
             f.write(c)
+
+    with open(log_config, "r") as f:
+        j = json.load(f)
+
+    if root_level and j["root"]["level"] != root_level:
+        j["root"]["level"] = root_level
+        with open(log_config, "w") as f:
+            json.dump(j, f, indent=2)
 
     return log_config
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -29,7 +29,7 @@ class MyTestCase(unittest.TestCase):
             wado_prefix="",
             qido_prefix="",
             stow_prefix="",
-            debug=False,
+            verbose="INFO",
             dryrun=True,
             conf={},
             host="0.0.0.0",


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>
- Bug in file extension for local datastore (xyz.abc.nii.gz was giving image id as xyz)
- Load/Create datastore over raw images quickly (skip computing filecheck sum over raw images)
- Deepedit interaction (use get with default for keys is_pos and is_neg stats)
- verbose option (e.g. monailabel start_server -v INFO  or monailabel start_server -v DEBUG)
- Option for user to pass result_write_to_file=False to skip writing label mask
- Save best 5 checkpoints on validation (change in monai causing to save checkpoint on every validation step)
- Docker verification step after docker build