### PR TITLE
Update requirements file for UNETR 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ schedule==1.1.0
 timeloop==1.0.2
 SimpleCRF==0.2.1.1
 numpy>=1.22.1
+einops==0.3.2


### PR DESCRIPTION
Signed-off-by: Andres <diazandr3s@gmail.com>

- Solve import error when using UNETR - Missing einops package

> File "/home/adp20local/anaconda3/envs/test_monai_env/lib/python3.6/site-packages/monai/utils/module.py", line 303, in optional_import
    pkg = __import__(module)  # top level module
monai.utils.module.OptionalImportError: import einops (No module named 'einops').
For details about installing the optional dependencies, please visit:
    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies