### PR TITLE
Option to run server with multiple workers and setting to limit infer…

### DIFF
--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
 
     MONAI_LABEL_SESSION_PATH: str = ""
     MONAI_LABEL_SESSION_EXPIRY: int = 3600
+    MONAI_LABEL_INFER_CONCURRENCY: int = -1
+    MONAI_LABEL_INFER_TIMEOUT: int = 600
 
     class Config:
         env_file = ".env"

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -16,6 +16,7 @@ import platform
 import shutil
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from distutils.util import strtobool
 from typing import Any, Callable, Dict, Optional, Sequence, Union
@@ -94,6 +95,12 @@ class MONAILabelApp:
         self._server_mode = strtobool(conf.get("server_mode", "false"))
         self._auto_update_scoring = strtobool(conf.get("auto_update_scoring", "true"))
         self._sessions = self._load_sessions(strtobool(conf.get("sessions", "true")))
+
+        self._infers_threadpool = (
+            None
+            if settings.MONAI_LABEL_INFER_CONCURRENCY < 0
+            else ThreadPoolExecutor(max_workers=settings.MONAI_LABEL_INFER_CONCURRENCY, thread_name_prefix="INFER")
+        )
 
     def init_infers(self) -> Dict[str, InferTask]:
         return {}
@@ -228,7 +235,15 @@ class MONAILabelApp:
             request["image"] = [os.path.join(f, request["image"]) for f in os.listdir(request["image"])]
 
         logger.info(f"Image => {request['image']}")
-        result_file_name, result_json = task(request)
+        if self._infers_threadpool:
+
+            def run_infer_in_thread(t, r):
+                return t(r)
+
+            f = self._infers_threadpool.submit(run_infer_in_thread, t=task, r=request)
+            result_file_name, result_json = f.result(request.get("timeout", settings.MONAI_LABEL_INFER_TIMEOUT))
+        else:
+            result_file_name, result_json = task(request)
 
         label_id = None
         if result_file_name and os.path.exists(result_file_name):


### PR DESCRIPTION
… tasks per worker

Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Default values will continue current behavior while starting the server.  So adding these new settings won't affect the way current server runs.

You can run (4 workers)
`./monailabel/scripts/monailabel start_server -a sample-apps/segmentation -s ~/Data/Test/ -v INFO --workers 4`

To limit concurrent number of infer tasks running per worker as:
`MONAI_LABEL_INFER_CONCURRENCY=2 ./monailabel/scripts/monailabel start_server -a sample-apps/segmentation -s ~/Data/Test/ -v INFO`

This allows max 2 inference tasks per worker (which u can configure depending on the GPU resource available) running at the same time.

This will still not solve multi-gpu inference.. which can be addressed in another problem/issue/pull request.