### PR TITLE
Fix docs build dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ expiringdict==1.2.1
 schedule==1.1.0
 timeloop==1.0.2
 SimpleCRF==0.2.1.1
-numpy>=1.22.1
+numpy>=1.21.5
 einops==0.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     schedule==1.1.0
     timeloop==1.0.2
     SimpleCRF==0.2.1.1
-    numpy>=1.22.1
+    numpy>=1.21.5
     einops==0.3.2
 
 [flake8]


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

because of python3.7 may be latest 1.22.x numpy is not available )
https://readthedocs.org/projects/monailabel/builds/16224068/