### PR TITLE
Support logging level at runtime + fix openslide dependency

### DIFF
--- a/.azure/azure-build-test-gpu-pipeline.yml
+++ b/.azure/azure-build-test-gpu-pipeline.yml
@@ -18,6 +18,7 @@ stages:
               sudo apt-get update --fix-missing -y
               sudo apt-get install -f -y
               sudo apt update && sudo apt install -y python3-pip python-is-python3
+              sudo apt-get install openslide-tools -y
               python3 -m pip install --upgrade pip wheel
               python3 -m pip install -r requirements-dev.txt
               python3 -m pip install pytest-azurepipelines
@@ -68,6 +69,7 @@ stages:
               sudo apt-get update --fix-missing -y
               sudo apt-get install -f -y
               sudo apt update && sudo apt install -y python3-pip python-is-python3 npm
+              sudo apt-get install openslide-tools -y
               sudo npm install --global yarn
               python3 -m pip install --user --upgrade pip setuptools wheel
               python3 -m pip install torch>=1.5 torchvision

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -26,6 +26,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
+          sudo apt-get install openslide-tools -y
           python -m pip install --upgrade pip wheel
           pip install -r requirements-dev.txt
       - name: Clean
@@ -79,6 +80,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
       - name: Install dependencies
         run: |
+          sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
           python -m pip install torch>=1.5 torchvision
       - name: Build Package
@@ -135,6 +137,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
       - name: Install dependencies
         run: |
+          sudo apt-get install openslide-tools -y
           python -m pip install --upgrade pip wheel
           python -m pip install -r docs/requirements.txt
       - name: Make html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
       - name: Install dependencies
         run: |
+          sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
           python -m pip install torch>=1.5 torchvision
       - name: Build Package

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: 3.8
       - name: Install setuptools
         run: |
+          sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade setuptools wheel
       - name: Generate HEAD Commit Id
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
 #  system_packages: true

--- a/monailabel/client/__init__.py
+++ b/monailabel/client/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .client import MONAILabelClient

--- a/monailabel/client/client.py
+++ b/monailabel/client/client.py
@@ -1,0 +1,392 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cgi
+import http.client
+import json
+import logging
+import mimetypes
+import os
+import tempfile
+from urllib.parse import quote_plus, urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class MONAILabelClient:
+    def __init__(self, server_url, tmpdir=None, client_id=None):
+        self._server_url = server_url.rstrip("/").strip()
+        self._tmpdir = tmpdir if tmpdir else tempfile.tempdir if tempfile.tempdir else "/tmp"
+        self._client_id = client_id
+
+    def _update_client_id(self, params):
+        if params:
+            params["client_id"] = self._client_id
+        else:
+            params = {"client_id": self._client_id}
+        return params
+
+    def get_server_url(self):
+        return self._server_url
+
+    def set_server_url(self, server_url):
+        self._server_url = server_url.rstrip("/").strip()
+
+    def info(self):
+        selector = "/info/"
+        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def next_sample(self, strategy, params):
+        params = self._update_client_id(params)
+        selector = "/activelearning/{}".format(MONAILabelUtils.urllib_quote_plus(strategy))
+        status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def create_session(self, image_in, params=None):
+        selector = "/session/"
+        params = self._update_client_id(params)
+
+        status, response, _ = MONAILabelUtils.http_upload("PUT", self._server_url, selector, params, [image_in])
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def get_session(self, session_id):
+        selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
+        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def remove_session(self, session_id):
+        selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
+        status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def upload_image(self, image_in, image_id=None, params=None):
+        selector = "/datastore/?image={}".format(MONAILabelUtils.urllib_quote_plus(image_id))
+
+        files = {"file": image_in}
+        params = self._update_client_id(params)
+        fields = {"params": json.dumps(params) if params else "{}"}
+
+        status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, response),
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def save_label(self, image_in, label_in, tag="", params=None):
+        selector = "/datastore/label?image={}".format(MONAILabelUtils.urllib_quote_plus(image_in))
+        if tag:
+            selector += "&tag={}".format(MONAILabelUtils.urllib_quote_plus(tag))
+
+        params = self._update_client_id(params)
+        fields = {
+            "params": json.dumps(params),
+        }
+        files = {"label": label_in}
+
+        status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, response),
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def infer(self, model, image_in, params, label_in=None, file=None, session_id=None):
+        selector = "/infer/{}?image={}".format(
+            MONAILabelUtils.urllib_quote_plus(model),
+            MONAILabelUtils.urllib_quote_plus(image_in),
+        )
+        if session_id:
+            selector += f"&session_id={MONAILabelUtils.urllib_quote_plus(session_id)}"
+
+        params = self._update_client_id(params)
+        fields = {"params": json.dumps(params) if params else "{}"}
+        files = {"label": label_in} if label_in else {}
+        files.update({"file": file} if file and not session_id else {})
+
+        status, form, files = MONAILabelUtils.http_multipart("POST", self._server_url, selector, fields, files)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, form),
+            )
+
+        form = json.loads(form) if isinstance(form, str) else form
+        params = form.get("params") if files else form
+        params = json.loads(params) if isinstance(params, str) else params
+
+        image_out = MONAILabelUtils.save_result(files, self._tmpdir)
+        return image_out, params
+
+    def train_start(self, model, params):
+        params = self._update_client_id(params)
+
+        selector = "/train/"
+        if model:
+            selector += MONAILabelUtils.urllib_quote_plus(model)
+
+        status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, response),
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def train_stop(self):
+        selector = "/train/"
+        status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, response),
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+    def train_status(self, check_if_running=False):
+        selector = "/train/"
+        if check_if_running:
+            selector += "?check_if_running=true"
+        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        if check_if_running:
+            return status == 200
+
+        if status != 200:
+            raise MONAILabelException(
+                MONAILabelError.SERVER_ERROR,
+                "Status: {}; Response: {}".format(status, response),
+            )
+
+        response = response.decode("utf-8") if isinstance(response, bytes) else response
+        logging.debug("Response: {}".format(response))
+        return json.loads(response)
+
+
+class MONAILabelError:
+    RESULT_NOT_FOUND = 1
+    SERVER_ERROR = 2
+    SESSION_EXPIRED = 3
+    UNKNOWN = 4
+
+
+class MONAILabelException(Exception):
+    __slots__ = ["error", "msg"]
+
+    def __init__(self, error, msg, status_code=None, response=None):
+        self.error = error
+        self.msg = msg
+        self.status_code = status_code
+        self.response = response
+
+
+class MONAILabelUtils:
+    @staticmethod
+    def http_method(method, server_url, selector, body=None):
+        logging.debug("{} {}{}".format(method, server_url, selector))
+
+        parsed = urlparse(server_url)
+        path = parsed.path.rstrip("/")
+        selector = path + "/" + selector.lstrip("/")
+        logging.debug("URI Path: {}".format(selector))
+
+        conn = http.client.HTTPConnection(parsed.hostname, parsed.port)
+        headers = {}
+        if body:
+            if isinstance(body, dict):
+                body = json.dumps(body)
+                content_type = "application/json"
+            else:
+                content_type = "text/plain"
+            headers = {"content-type": content_type, "content-length": str(len(body))}
+
+        conn.request(method, selector, body=body, headers=headers)
+        return MONAILabelUtils.send_response(conn)
+
+    @staticmethod
+    def http_upload(method, server_url, selector, fields, files):
+        logging.debug("{} {}{}".format(method, server_url, selector))
+
+        url = server_url.rstrip("/") + "/" + selector.lstrip("/")
+        logging.debug("URL: {}".format(url))
+
+        files = [("files", (os.path.basename(f), open(f, "rb"))) for f in files]
+        response = requests.post(url, files=files) if method == "POST" else requests.put(url, files=files, data=fields)
+        return response.status_code, response.text, None
+
+    @staticmethod
+    def http_multipart(method, server_url, selector, fields, files):
+        logging.debug("{} {}{}".format(method, server_url, selector))
+
+        content_type, body = MONAILabelUtils.encode_multipart_formdata(fields, files)
+        headers = {"content-type": content_type, "content-length": str(len(body))}
+
+        parsed = urlparse(server_url)
+        path = parsed.path.rstrip("/")
+        selector = path + "/" + selector.lstrip("/")
+        logging.debug("URI Path: {}".format(selector))
+
+        conn = http.client.HTTPConnection(parsed.hostname, parsed.port)
+        conn.request(method, selector, body, headers)
+        return MONAILabelUtils.send_response(conn, content_type)
+
+    @staticmethod
+    def send_response(conn, content_type="application/json"):
+        response = conn.getresponse()
+        logging.debug("HTTP Response Code: {}".format(response.status))
+        logging.debug("HTTP Response Message: {}".format(response.reason))
+        logging.debug("HTTP Response Headers: {}".format(response.getheaders()))
+
+        response_content_type = response.getheader("content-type", content_type)
+        logging.debug("HTTP Response Content-Type: {}".format(response_content_type))
+
+        if "multipart" in response_content_type:
+            if response.status == 200:
+                form, files = MONAILabelUtils.parse_multipart(response.fp if response.fp else response, response.msg)
+                logging.debug("Response FORM: {}".format(form))
+                logging.debug("Response FILES: {}".format(files.keys()))
+                return response.status, form, files
+            else:
+                return response.status, response.read(), None
+
+        logging.debug("Reading status/content from simple response!")
+        return response.status, response.read(), None
+
+    @staticmethod
+    def save_result(files, tmpdir):
+        logging.info(f"Files: {files.keys()} => {tmpdir}")
+        for name in files:
+            data = files[name]
+            result_file = os.path.join(tmpdir, name)
+
+            logging.info("Saving {} to {}; Size: {}".format(name, result_file, len(data)))
+            dir_path = os.path.dirname(os.path.realpath(result_file))
+            if not os.path.exists(dir_path):
+                os.makedirs(dir_path)
+
+            with open(result_file, "wb") as f:
+                if isinstance(data, bytes):
+                    f.write(data)
+                else:
+                    f.write(data.encode("utf-8"))
+
+            # Currently only one file per response supported
+            return result_file
+
+    @staticmethod
+    def encode_multipart_formdata(fields, files):
+        limit = "----------lImIt_of_THE_fIle_eW_$"
+        lines = []
+        for (key, value) in fields.items():
+            lines.append("--" + limit)
+            lines.append('Content-Disposition: form-data; name="%s"' % key)
+            lines.append("")
+            lines.append(value)
+        for (key, filename) in files.items():
+            if isinstance(filename, tuple):
+                filename, data = filename
+            else:
+                with open(filename, mode="rb") as f:
+                    data = f.read()
+
+            lines.append("--" + limit)
+            lines.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename))
+            lines.append("Content-Type: %s" % MONAILabelUtils.get_content_type(filename))
+            lines.append("")
+            lines.append(data)
+        lines.append("--" + limit + "--")
+        lines.append("")
+
+        body = bytearray()
+        for line in lines:
+            body.extend(line if isinstance(line, bytes) else line.encode("utf-8"))
+            body.extend(b"\r\n")
+
+        content_type = "multipart/form-data; boundary=%s" % limit
+        return content_type, body
+
+    @staticmethod
+    def get_content_type(filename):
+        return mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+    @staticmethod
+    def parse_multipart(fp, headers):
+        fs = cgi.FieldStorage(
+            fp=fp,
+            environ={"REQUEST_METHOD": "POST"},
+            headers=headers,
+            keep_blank_values=True,
+        )
+        form = {}
+        files = {}
+        if hasattr(fs, "list") and isinstance(fs.list, list):
+            for f in fs.list:
+                logger.debug("FILE-NAME: {}; NAME: {}; SIZE: {}".format(f.filename, f.name, len(f.value)))
+                if f.filename:
+                    files[f.filename] = f.value
+                else:
+                    form[f.name] = f.value
+        return form, files
+
+    @staticmethod
+    def urllib_quote_plus(s):
+        return quote_plus(s)

--- a/monailabel/client/client.py
+++ b/monailabel/client/client.py
@@ -46,7 +46,7 @@ class MONAILabelClient:
         selector = "/info/"
         status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
             )
 
@@ -59,7 +59,7 @@ class MONAILabelClient:
         selector = "/activelearning/{}".format(MONAILabelUtils.urllib_quote_plus(strategy))
         status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
             )
 
@@ -73,7 +73,7 @@ class MONAILabelClient:
 
         status, response, _ = MONAILabelUtils.http_upload("PUT", self._server_url, selector, params, [image_in])
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
             )
 
@@ -85,7 +85,7 @@ class MONAILabelClient:
         selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
         status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
             )
 
@@ -97,7 +97,7 @@ class MONAILabelClient:
         selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
         status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR, "Status: {}; Response: {}".format(status, response), status, response
             )
 
@@ -114,7 +114,7 @@ class MONAILabelClient:
 
         status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, response),
             )
@@ -136,7 +136,7 @@ class MONAILabelClient:
 
         status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, response),
             )
@@ -160,7 +160,7 @@ class MONAILabelClient:
 
         status, form, files = MONAILabelUtils.http_multipart("POST", self._server_url, selector, fields, files)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, form),
             )
@@ -181,7 +181,7 @@ class MONAILabelClient:
 
         status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, response),
             )
@@ -194,7 +194,7 @@ class MONAILabelClient:
         selector = "/train/"
         status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, response),
             )
@@ -212,7 +212,7 @@ class MONAILabelClient:
             return status == 200
 
         if status != 200:
-            raise MONAILabelException(
+            raise MONAILabelClientException(
                 MONAILabelError.SERVER_ERROR,
                 "Status: {}; Response: {}".format(status, response),
             )
@@ -229,7 +229,7 @@ class MONAILabelError:
     UNKNOWN = 4
 
 
-class MONAILabelException(Exception):
+class MONAILabelClientException(Exception):
     __slots__ = ["error", "msg"]
 
     def __init__(self, error, msg, status_code=None, response=None):

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -234,7 +234,7 @@ class MONAILabelApp:
             logger.info(os.listdir(request["image"]))
             request["image"] = [os.path.join(f, request["image"]) for f in os.listdir(request["image"])]
 
-        logger.info(f"Image => {request['image']}")
+        logger.debug(f"Image => {request['image']}")
         if self._infers_threadpool:
 
             def run_infer_in_thread(t, r):
@@ -248,9 +248,9 @@ class MONAILabelApp:
         label_id = None
         if result_file_name and os.path.exists(result_file_name):
             tag = request.get("label_tag", DefaultLabelTag.ORIGINAL)
-            save_label = request.get("save_label", True)
+            save_label = request.get("save_label", False)
             if save_label:
-                label_id = datastore.save_label(image_id, result_file_name, tag, result_json)
+                label_id = datastore.save_label(image_id, result_file_name, tag, dict())
             else:
                 label_id = result_file_name
 

--- a/monailabel/interfaces/tasks/infer.py
+++ b/monailabel/interfaces/tasks/infer.py
@@ -283,7 +283,7 @@ class InferTask:
 
         if result_file_name:
             logger.info("Result File: {}".format(result_file_name))
-            logger.info("Result Json: {}".format(list(result_json.keys())))
+            logger.info("Result Json Keys: {}".format(list(result_json.keys())))
         return result_file_name, result_json
 
     def run_pre_transforms(self, data, transforms):

--- a/monailabel/interfaces/tasks/infer.py
+++ b/monailabel/interfaces/tasks/infer.py
@@ -230,6 +230,7 @@ class InferTask:
         # device
         device = req.get("device", "cuda")
         req["device"] = device
+        logger.setLevel(req.get("logging", "INFO").upper())
         logger.info(f"Infer Request (final): {req}")
 
         data = copy.deepcopy(req)
@@ -282,7 +283,7 @@ class InferTask:
 
         if result_file_name:
             logger.info("Result File: {}".format(result_file_name))
-            logger.info("Result Json: {}".format(result_json))
+            logger.info("Result Json: {}".format(list(result_json.keys())))
         return result_file_name, result_json
 
     def run_pre_transforms(self, data, transforms):
@@ -367,7 +368,7 @@ class InferTask:
         """
 
         inferer = self.inferer(data)
-        logger.info("Running Inferer:: {} => {}".format(inferer.__class__.__name__, inferer.__dict__))
+        logger.info("Inferer:: {} => {}".format(inferer.__class__.__name__, inferer.__dict__))
 
         if device.startswith("cuda") and not torch.cuda.is_available():
             device = "cpu"
@@ -402,7 +403,7 @@ class InferTask:
         :param dtype: output label dtype
         :return: tuple of output_file and result_json
         """
-        logger.info("Writing Result")
+        logger.info("Writing Result...")
         if extension is not None:
             data["result_extension"] = extension
         if dtype is not None:

--- a/monailabel/interfaces/utils/transform.py
+++ b/monailabel/interfaces/utils/transform.py
@@ -58,8 +58,9 @@ def run_transforms(data, callables, inverse=False, log_prefix="POST", log_name="
     :param use_compose: Use Compose to run individual callables
     :return: Processed data after running transforms
     """
-    logger.info("{} - Run {}".format(log_prefix, log_name))
-    logger.info("{} - Input Keys: {}".format(log_prefix, data.keys()))
+    logger.setLevel(data.get("logging", "INFO").upper())
+    logger.info("{} - Run {}(s)".format(log_prefix, log_name))
+    logger.info("{} - Input Keys: {}".format(log_prefix, list(data.keys())))
 
     if not callables:
         return data

--- a/monailabel/transform/writer.py
+++ b/monailabel/transform/writer.py
@@ -84,12 +84,14 @@ class Writer:
         self.nibabel = nibabel
 
     def __call__(self, data):
+        logger.setLevel(data.get("logging", "INFO").upper())
+
         ext = file_ext(data.get("image_path"))
         dtype = data.get(self.key_dtype, None)
         compress = data.get(self.key_compress, False)
         write_to_file = data.get(self.key_write_to_file, True)
         ext = data.get(self.key_extension) if data.get(self.key_extension) else ext
-        logger.info("Result ext: {}".format(ext))
+        logger.info(f"Result ext: {ext}; write_to_file: {write_to_file}")
 
         image_np = data[self.label]
         meta_dict = data.get(f"{self.ref_image}_{self.meta_key_postfix}")

--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -24,7 +24,12 @@ logger = logging.getLogger(__name__)
 
 
 def file_ext(name) -> str:
-    return "".join(pathlib.Path(name).suffixes) if name else ""
+    suffixes = []
+    for s in reversed(pathlib.Path(name).suffixes):
+        if len(s) > 10:
+            break
+        suffixes.append(s)
+    return "".join(reversed(suffixes)) if name else ""
 
 
 def remove_file(path: str) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,5 @@ parameterized
 types-PyYAML
 types-filelock
 types-requests
+click
+testresources

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,8 @@ timeloop==1.0.2
 SimpleCRF==0.2.1.1
 numpy>=1.21.5
 einops==0.3.2
+openslide-python==1.1.2
+opencv-python==4.5.4.60
+Shapely==1.8.0
+
+#sudo apt-get install openslide-tools -y

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ install_requires =
     SimpleCRF==0.2.1.1
     numpy>=1.21.5
     einops==0.3.2
+    openslide-python==1.1.2
+    opencv-python==4.5.4.60
+    Shapely==1.8.0
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

- Log fixes
- Infer request can send logging parameter  `logging=INFO/WARN/ERROR` to disable logging while running the infer request.
- Open Slide dependency for the build
- Add reusable PyClient API monailabel.client (which is currently used in 3D Slicer) (Later this can be a separate PY package)
- By Default do not save infer labels/result (origin tag).  Save only when user wants to save by sending `save_label`
