### PR TITLE
remove icon filepath from Slicer UI file

### DIFF
--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -42,10 +42,6 @@
        <property name="text">
         <string/>
        </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>refresh-icon.png</normaloff>refresh-icon.png</iconset>
-       </property>
       </widget>
      </item>
      <item row="1" column="0">
@@ -105,10 +101,6 @@
        </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>upload.svg</normaloff>upload.svg</iconset>
        </property>
       </widget>
      </item>
@@ -349,10 +341,6 @@
         </property>
         <property name="text">
          <string>Run</string>
-        </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>monai-label-icon.png</normaloff>monai-label-icon.png</iconset>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This removes some icon filepath specifications from the UI file for the MonaiLabel module for Slicer. These paths were not actually working due to incorrect relative path to the icon. They would have been needed to be updated to something like `../Icons/refresh-icon.png`. 

I'm removing these specifications from the UI file because they are instead setup in the python code for the MonaiLabel module as seen below:
https://github.com/Project-MONAI/MONAILabel/blob/bbe26982a9b53c67d09be099034b937afcfb6769/plugins/slicer/MONAILabel/MONAILabel.py#L252-L259