### PR TITLE
SimpleCRF install fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pynetdicom==2.0.1
 expiringdict==1.2.1
 schedule==1.1.0
 timeloop==1.0.2
-SimpleCRF==0.2.1.1
+SimpleCRF-binaries==0.2.1.2
 numpy>=1.21.5
 einops>=0.3.2
 openslide-python==1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     expiringdict==1.2.1
     schedule==1.1.0
     timeloop==1.0.2
-    SimpleCRF==0.2.1.1
+    SimpleCRF-binaries==0.2.1.2
     numpy>=1.21.5
     einops>=0.3.2
     openslide-python==1.1.2


### PR DESCRIPTION
As mentioned in [this thread](https://github.com/HiLab-git/SimpleCRF/issues/7#issuecomment-1088632474), a fix for installing SimpleCRF that uses precompiled binaries was developed. A temporary PyPI project was made, which means that installing SimpleCRF on all platforms is much easier, and solves the issue mentioned in the issue #719. The PyPI project is called [SimpleCRF-binaries](https://pypi.org/project/SimpleCRF-binaries/).

I have made the necessary modifications to the install procedure of MONAI Label to use the new package.

However, run some unit tests just to verify that the package installs and works as expected with MONAI Label.