### PR TITLE
drop python 3.6 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code=https://github.com/Project-MONAI/MONAILabel
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 # for compiling and develop setup only
 # no need to specify the versions so that we could
 # compile for multiple targeted versions.


### PR DESCRIPTION
This is a follow-up to #378 and is possible as Slicer client upgraded to Python 3.9 from Python 3.6 (https://github.com/Project-MONAI/MONAILabel/pull/378#issuecomment-1021702308). 

Monai has dropped Python 3.6 support (https://github.com/Project-MONAI/MONAI/commit/e655b4e4898c314cbc9d4d6da8f70ff1162cab7e). PyTorch dropped Python 3.6 starting in version 1.11.0 (https://github.com/pytorch/pytorch/commit/dc5cda0cca429a3080f63e7b30b3e87d18df8601).

Python 3.6 official end of support date was 23rd Dec 2021.

Signed-off-by: James Butler <jbutler@sonovol.com>