### PR TITLE
update PY_REQUIRED_MINOR to reflect python 3.7 minimum

### DIFF
--- a/.azure/azure-build-test-gpu-pipeline.yml
+++ b/.azure/azure-build-test-gpu-pipeline.yml
@@ -72,7 +72,7 @@ stages:
               sudo apt-get install openslide-tools -y
               sudo npm install --global yarn
               python3 -m pip install --user --upgrade pip setuptools wheel
-              python3 -m pip install torch>=1.5 torchvision
+              python3 -m pip install torch>=1.6 torchvision
             displayName: 'Install dependencies'
           - script: |
               python setup.py sdist bdist_wheel

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
-          python -m pip install torch>=1.5 torchvision
+          python -m pip install torch>=1.6 torchvision
       - name: Build Package
         run: |
           python setup.py sdist bdist_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
-          python -m pip install torch>=1.5 torchvision
+          python -m pip install torch>=1.6 torchvision
       - name: Build Package
         run: |
           python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')

--- a/monailabel/__init__.py
+++ b/monailabel/__init__.py
@@ -15,7 +15,7 @@ import sys
 from ._version import get_versions
 
 PY_REQUIRED_MAJOR = 3
-PY_REQUIRED_MINOR = 6
+PY_REQUIRED_MINOR = 7
 
 version_dict = get_versions()
 __version__ = version_dict.get("version", "0+unknown")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "wheel",
   "setuptools",
-  "torch>=1.5",
+  "torch>=1.6",
   "ninja",
 ]
 


### PR DESCRIPTION
This is a follow-up to #735 to update the `PY_REQUIRED_MINOR` usage to 7 to reflect python 3.7 as the new minimum.

This also includes a bump of the torch minimum to match what is in latest Monai.