### PR TITLE
remove workaround for SimpleITK python 3.10 whl compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 aiofiles==0.8.0
 fastapi==0.73.0
-# https://github.com/SimpleITK/SimpleITK/issues/1627#issuecomment-1094288209
-SimpleITK==2.1.1.1; python_version == '3.10'
-SimpleITK>=2.1.1
+SimpleITK>=2.1
 monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]>=0.8.1
 PyYAML==6.0
 python-multipart==0.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,7 @@ setup_requires =
 install_requires =
     aiofiles==0.8.0
     fastapi==0.73.0
-    # https://github.com/SimpleITK/SimpleITK/issues/1627#issuecomment-1094288209
-    SimpleITK==2.1.1.1; python_version == '3.10'
-    SimpleITK>=2.1.1
+    SimpleITK>=2.1
     monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide]>=0.8.1
     PyYAML==6.0
     python-multipart==0.0.5


### PR DESCRIPTION
SimpleITK 2.1.1.2 was released with whl files for Python 3.6-3.10. https://pypi.org/project/SimpleITK/2.1.1.2/#files

Signed-off-by: James Butler <jbutler@sonovol.com>