### PR TITLE
Switch Scribbles optimisation to numpymaxflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ with [MONAI](https://github.com/Project-MONAI).
 
 ## Installation
 
-**MONAI Label requires PyTorch version 1.10.0 or newer.**
-
 MONAI Label supports following OS with **GPU/CUDA** enabled.
 
 - Ubuntu

--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -32,7 +32,7 @@ class HistogramBasedGraphCut(InferTask):
     indicating foreground and background regions. A likelihood volume is generated using histogram method.
     User-scribbles are incorporated using Equation 7 on page 4 of the paper.
 
-    SimpleCRF's GraphCut layer is used to optimise Equation 5 from the paper, where unaries come from Equation 7
+    numpymaxflow's GraphCut layer is used to optimise Equation 5 from the paper, where unaries come from Equation 7
     and pairwise is the original input volume.
     """
 

--- a/monailabel/scribbles/transforms.py
+++ b/monailabel/scribbles/transforms.py
@@ -339,7 +339,7 @@ class ApplyGraphCutOptimisationd(InteractiveSegmentationTransform):
 
     This can be used in conjuction with any Make*Unaryd transform
     (e.g. MakeISegUnaryd from above for implementing ISeg unary term).
-    It optimises a typical energy function for interactive segmentation methods using SimpleCRF's GraphCut method,
+    It optimises a typical energy function for interactive segmentation methods using numpymaxflow's GraphCut method,
     e.g. Equation 5 from https://arxiv.org/pdf/1710.04043.pdf.
 
     Usage Example::
@@ -401,15 +401,12 @@ class ApplyGraphCutOptimisationd(InteractiveSegmentationTransform):
         if unary_term.shape[0] > 2:
             raise ValueError(f"GraphCut can only be applied to binary probabilities, received {unary_term.shape[0]}")
 
-        # # attempt to unfold probability term
+        # attempt to unfold probability term
         # unary_term = self._unfold_prob(unary_term, axis=0)
 
-        # prepare data for SimpleCRF's GraphCut
-        unary_term = torch.from_numpy(unary_term).unsqueeze(0)
-        pairwise_term = torch.from_numpy(pairwise_term).unsqueeze(0)
-
+        # prepare data for numpymaxflow's GraphCut
         # run GraphCut
-        post_proc_label = maxflow(pairwise_term, unary_term, lamda=self.lamda, sigma=self.sigma).squeeze(0).numpy()
+        post_proc_label = maxflow(pairwise_term, unary_term, lamda=self.lamda, sigma=self.sigma)
 
         d[self.post_proc_label] = post_proc_label
 

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -12,7 +12,6 @@ import logging
 
 import numpy as np
 import numpymaxflow
-from monai.utils import optional_import
 
 logger = logging.getLogger(__name__)
 

--- a/monailabel/scribbles/utils.py
+++ b/monailabel/scribbles/utils.py
@@ -11,11 +11,8 @@
 import logging
 
 import numpy as np
+import numpymaxflow
 from monai.utils import optional_import
-
-# torch import is needed to execute torchmaxflow
-optional_import("torch")
-import torchmaxflow
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +24,7 @@ def get_eps(data):
 def maxflow(image, prob, lamda=5, sigma=0.1):
     # lamda: weight of smoothing term
     # sigma: std of intensity values
-    return torchmaxflow.maxflow(image, prob, lamda, sigma)
+    return numpymaxflow.maxflow(image, prob, lamda, sigma)
 
 
 def make_iseg_unary(

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ openslide-python==1.1.2
 opencv-python-headless==4.5.5.64
 Shapely==1.8.1.post1
 girder_client==3.1.8
-torchmaxflow==0.0.6rc1
+numpymaxflow==0.0.2
 
 #sudo apt-get install openslide-tools -y

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     opencv-python-headless==4.5.5.64
     Shapely==1.8.1.post1
     girder_client==3.1.8
-    torchmaxflow==0.0.6rc1
+    numpymaxflow==0.0.2
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

Recent update to scribbles added torchmaxflow as dependency. As it is targetted for specific pytorch versions, it limits the usable pytorch version to specific versions (see https://github.com/Project-MONAI/MONAILabel/issues/746).
Also see related discussion to this at: https://github.com/Project-MONAI/MONAILabel/pull/731

This PR changes the dependency to numpymaxflow - a numpy-based maxflow implementation. This will release any pytorch version dependencies from monai label.

I have tested this on Ubuntu. May need to be tested for installation and a scribbles example on Windows. 