### PR TITLE
Quick fix copyright string in scribbles to be consistent with monai label

### DIFF
--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright (c) MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

No change in code, just updating copyright notice comment to be consistent with rest of the library