### PR TITLE
Fix for bug in scribbles labelmap

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1796,6 +1796,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
             # save scribbles + label to file
             slicer.util.saveNode(labelmapVolumeNode, scribbles_in)
+            slicer.mrmlScene.RemoveNode(labelmapVolumeNode)
             self.reportProgress(30)
             self.updateServerSettings()
             self.reportProgress(60)
@@ -1891,7 +1892,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for i in range(num_segments):
             segmentId = segmentation.GetSegmentation().GetNthSegmentID(i)
             if "scribbles" in segmentId:
-                logging.info(f"clearning {segmentId}")
+                logging.info(f"clearing {segmentId}")
                 labelMapRep = slicer.vtkOrientedImageData()
                 segmentation.GetBinaryLabelmapRepresentation(segmentId, labelMapRep)
                 vtkSegmentationCore.vtkOrientedImageDataResample.FillImage(labelMapRep, 0, labelMapRep.GetExtent())


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

In 3D Slicer plugin, the labelmap used for loading updates in `onUpdateScribbles()` was not being removed—leading to multiple residual labelmaps when running multiple update calls using scribbles. 

This PR provides a quick fix to resolve this memory/object leak. 