### PR TITLE
Modify some of the CLI for the DSA plugin.

### DIFF
--- a/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.py
+++ b/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.py
@@ -57,6 +57,8 @@ def fetch_annotations(args, tiles=None):
         "tile_size": tile_size,
         "min_poly_area": min_poly_area,
         "output": output,
+        "girder_api_url": args.girderApiUrl,
+        "girder_token": args.girderToken,
     }
     extra_params = json.loads(args.extra_params)
     body["params"] = {
@@ -74,7 +76,15 @@ def fetch_annotations(args, tiles=None):
     logging.info(f"Total Annotation Fetch time = {round(total_time_taken, 2)}")
 
 
+def get_model_names(args):
+    client = MONAILabelClient(server_url=args.server)
+    for model_name in client.info()['models']:
+        print('<element>%s</element>' % model_name)
+
+
 def main(args):
+    if args.model_name == '__datalist__':
+        return get_model_names(args)
     total_start_time = time.time()
     print("\n>> CLI Parameters ...\n")
     for arg in vars(args):

--- a/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.py
+++ b/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.py
@@ -78,12 +78,12 @@ def fetch_annotations(args, tiles=None):
 
 def get_model_names(args):
     client = MONAILabelClient(server_url=args.server)
-    for model_name in client.info()['models']:
-        print('<element>%s</element>' % model_name)
+    for model_name in client.info()["models"]:
+        print("<element>%s</element>" % model_name)
 
 
 def main(args):
-    if args.model_name == '__datalist__':
+    if args.model_name == "__datalist__":
         return get_model_names(args)
     total_start_time = time.time()
     print("\n>> CLI Parameters ...\n")

--- a/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.xml
+++ b/plugins/dsa/cli/MONAILabelAnnotation/MONAILabelAnnotation.xml
@@ -33,9 +33,9 @@
             <label>MONAILabel Address</label>
             <description>Address of a monailabel address in the format 'http://127.0.0.1:8000/'.</description>
             <longflag>server</longflag>
-            <default>http://10.117.16.216:8000/</default>
+            <default>{{env_MONAI_LABEL_SERVER|default("http://10.117.18.128:8000/")}}</default>
         </string>
-        <string>
+        <string datalist="{&quot;model_name&quot;: &quot;__datalist__&quot;, &quot;inputImageFile&quot;: &quot;skip&quot;, &quot;outputAnnotationFile&quot;: &quot;skip&quot;, &quot;outputAnnotationFile_folder&quot;: &quot;skip&quot;}">
             <name>model_name</name>
             <label>Model Name</label>
             <description>DeepLearning Model to Infer (For Example: deepedit_nuclei, segmentation_nuclei)</description>
@@ -71,6 +71,20 @@
             <description>Extra/Other Config Parameters defined by MONAILabel inference task</description>
             <longflag>extra_params</longflag>
             <default>{}</default>
+        </string>
+        <string>
+            <name>girderApiUrl</name>
+            <longflag>api-url</longflag>
+            <label>Girder API URL</label>
+            <description>A Girder API URL (e.g., https://girder.example.com:443/api/v1)</description>
+            <default></default>
+        </string>
+        <string>
+            <name>girderToken</name>
+            <longflag>girder-token</longflag>
+            <label>Girder Token</label>
+            <description>A Girder token</description>
+            <default></default>
         </string>
     </parameters>
     <parameters advanced="true">

--- a/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.py
+++ b/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.py
@@ -19,7 +19,15 @@ from histomicstk.cli.utils import CLIArgumentParser
 logging.basicConfig(level=logging.INFO)
 
 
+def get_model_names(args):
+    client = MONAILabelClient(server_url=args.server)
+    for model_name in client.info()['models']:
+        print('<element>%s</element>' % model_name)
+
+
 def main(args):
+    if args.model_name == '__datalist__':
+        return get_model_names(args)
     print("\n>> CLI Parameters ...\n")
     for arg in vars(args):
         print(f"USING:: {arg} = {getattr(args, arg)}")
@@ -36,6 +44,8 @@ def main(args):
         "dataset_limit": args.dataset_limit,
         "dataset_max_region": args.dataset_max_region,
         "dataset_randomize": args.dataset_randomize,
+        "girder_api_url": args.girderApiUrl,
+        "girder_token": args.girderToken,
     }
     extra_params = json.loads(args.extra_params)
     params.update(extra_params)

--- a/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.py
+++ b/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.py
@@ -21,12 +21,12 @@ logging.basicConfig(level=logging.INFO)
 
 def get_model_names(args):
     client = MONAILabelClient(server_url=args.server)
-    for model_name in client.info()['models']:
-        print('<element>%s</element>' % model_name)
+    for model_name in client.info()["models"]:
+        print("<element>%s</element>" % model_name)
 
 
 def main(args):
-    if args.model_name == '__datalist__':
+    if args.model_name == "__datalist__":
         return get_model_names(args)
     print("\n>> CLI Parameters ...\n")
     for arg in vars(args):

--- a/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.xml
+++ b/plugins/dsa/cli/MONAILabelTraining/MONAILabelTraining.xml
@@ -16,14 +16,28 @@
             <label>MONAILabel Address</label>
             <description>Address of a monailabel address in the format 'http://127.0.0.1:8000/'.</description>
             <longflag>server</longflag>
-            <default>http://10.117.16.216:8000/</default>
+            <default>{{env_MONAI_LABEL_SERVER|default("http://10.117.18.128:8000/")}}</default>
         </string>
-        <string>
+        <string datalist="{&quot;model_name&quot;: &quot;__datalist__&quot;}">
             <name>model_name</name>
             <label>Model Name</label>
             <description>DeepLearning Model to Train/Finetune (For Example: deepedit_nuclei, segmentation_nuclei)</description>
             <longflag>model_name</longflag>
             <default>deepedit_nuclei</default>
+        </string>
+        <string>
+            <name>girderApiUrl</name>
+            <longflag>api-url</longflag>
+            <label>Girder API URL</label>
+            <description>A Girder API URL (e.g., https://girder.example.com:443/api/v1)</description>
+            <default></default>
+        </string>
+        <string>
+            <name>girderToken</name>
+            <longflag>girder-token</longflag>
+            <label>Girder Token</label>
+            <description>A Girder token</description>
+            <default></default>
         </string>
     </parameters>
     <parameters>


### PR DESCRIPTION
If used with the latest version of the DSA, this will pull model names from the MONAI Label server.

This passed the girder API URL and a girder token to the clis; these should be used in the label server to set up the dsa assetstore if they differ from what was last used.

When running the DSA, if an appropriate environment variable is added to the girder docker, it will locate the MONAI Label server from that value.  For instance:

```
services:
  girder:
    environment: 
      SLICER_CLI_WEB_MONAI_LABEL_SERVER: https://monai.label.server.com:8020
```