### PR TITLE
Add ROI placement widget for scribbles in Slicer plugin

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -2100,7 +2100,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         scribblesROINode.AddObserver(scribblesROINode.PointPositionDefinedEvent, self.onROIPointPlaced)
         scribblesROINode.SetName("Scribbles ROI")
         scribblesROINode.CreateDefaultDisplayNodes()
-        scribblesROINode.GetDisplayNode().SetFillOpacity(0.0)
+        scribblesROINode.GetDisplayNode().SetFillOpacity(0.4)
         scribblesROINode.GetDisplayNode().SetSelectedColor(1, 1, 1)
         scribblesROINode.GetDisplayNode().SetColor(1, 1, 1)
         scribblesROINode.GetDisplayNode().SetActiveColor(1, 1, 1)

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1926,15 +1926,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         v.GetRASToIJKMatrix(RasToIjkMatrix)
 
         roi_points_ras = [0.0] * 6
-        if roiNode.__class__.__name__ == "vtkMRMLMarkupsROINode":
-            # for vtkMRMLMarkupsROINode
-            center = [0] * 3
-            roiNode.GetCenter(center)
-            roi_points_ras = [(x - s / 2, x + s / 2) for x, s in zip(center, roiNode.GetSize())]
-            roi_points_ras = [item for sublist in roi_points_ras for item in sublist]
-        else:
-            # if none found then best to return empty list
-            return []
+        center = [0] * 3
+        roiNode.GetCenter(center)
+        roi_points_ras = [(x - s / 2, x + s / 2) for x, s in zip(center, roiNode.GetSize())]
+        roi_points_ras = [item for sublist in roi_points_ras for item in sublist]
 
         min_points_ras = [roi_points_ras[0], roi_points_ras[2], roi_points_ras[4], 1.0]
         max_points_ras = [roi_points_ras[0 + 1], roi_points_ras[2 + 1], roi_points_ras[4 + 1], 1.0]

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1866,7 +1866,9 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
             # try to get roi if placed
             roiNode = self.ui.scribblesPlaceWidget.currentNode()
-            selected_roi = self.getROIPointsXYZ(roiNode)
+            selected_roi = []
+            if roiNode and roiNode.GetControlPointPlacementComplete():
+                selected_roi = self.getROIPointsXYZ(roiNode)
 
             # send scribbles + label to server along with selected scribbles method
             params = self.getParamsFromConfig("infer", scribblesMethod)

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1931,15 +1931,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         roi_points_ras = [0.0] * 6
         if roiNode.__class__.__name__ == "vtkMRMLMarkupsROINode":
             # for vtkMRMLMarkupsROINode
-            print(roiNode.__class__.__name__)
             center = [0] * 3
             roiNode.GetCenter(center)
             roi_points_ras = [(x - s / 2, x + s / 2) for x, s in zip(center, roiNode.GetSize())]
             roi_points_ras = [item for sublist in roi_points_ras for item in sublist]
-        elif roiNode.__class__.__name__ == "vtkMRMLAnnotationROINode":
-            # for vtkMRMLAnnotationROINode (old method)
-            print(roiNode.__class__.__name__)
-            roiNode.GetBounds(roi_points_ras)
         else:
             # if none found then best to return empty list
             return []

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -389,9 +389,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.setParameterNode(None)
         self.current_sample = None
         self.samples.clear()
-        if self._scribblesROINode:
-            self._scribblesROINode.RemoveAllObservers()
-            self._scribblesROINode = None
+        self._scribblesROINode = None
 
         self.resetPointList(
             self.ui.dgPositiveControlPointPlacementWidget,
@@ -1617,7 +1615,6 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             return
         if self._scribblesROINode is None:
             scribblesROINode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
-            scribblesROINode.AddObserver(scribblesROINode.PointPositionDefinedEvent, self.onROIPointPlaced)
             scribblesROINode.SetName("Scribbles ROI")
             scribblesROINode.CreateDefaultDisplayNodes()
             scribblesROINode.GetDisplayNode().SetFillOpacity(0.4)
@@ -2108,10 +2105,6 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.checkAndInitialiseScribbles()
             effect = self._scribblesEditorWidget.activeEffect()
             effect.setParameter("BrushAbsoluteDiameter", value)
-
-    def onROIPointPlaced(self, caller_roi_node, event):
-        if caller_roi_node.GetControlPointPlacementComplete():
-            self.ui.scribblesPlaceWidget.setPlaceModeEnabled(False)  # General ROI placement persists otherwise
 
 
 class MONAILabelLogic(ScriptedLoadableModuleLogic):

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -650,7 +650,7 @@
           <item>
            <widget class="QLabel" name="scribblesROILabel">
             <property name="text">
-             <string>Place ROI:</string>
+             <string>ROI:</string>
             </property>
            </widget>
           </item>

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -645,6 +645,30 @@
         <item row="2" column="3">
          <widget class="QComboBox" name="scribLabelComboBox"/>
         </item>
+        <item row="0" column="6">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QLabel" name="scribblesROILabel">
+            <property name="text">
+             <string>Place ROI:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="qSlicerMarkupsPlaceWidget" name="scribblesPlaceWidget">
+            <property name="placeMultipleMarkups">
+             <enum>qSlicerMarkupsPlaceWidget::ForcePlaceMultipleMarkups</enum>
+            </property>
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </item>
      </layout>

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -657,7 +657,7 @@
           <item>
            <widget class="qSlicerMarkupsPlaceWidget" name="scribblesPlaceWidget">
             <property name="placeMultipleMarkups">
-             <enum>qSlicerMarkupsPlaceWidget::ForcePlaceMultipleMarkups</enum>
+             <enum>qSlicerMarkupsPlaceWidget::ForcePlaceSingleMarkup</enum>
             </property>
             <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">


### PR DESCRIPTION
Took a crack at #433 as I'm working on some other ROI tools here. These changes add an ROI placement widget for scribbles in the Slicer plugin so the interface is more direct and there's no reliance on externally defined ROIs.

Right now the GUI looks like this for me on my windows machine as all I've done is add a new row for the markup placement widget. I think probably it would be suited better in the second row so there is more of a progression of operations from top to bottom, but looking for some input here. Perhaps some of the other UI elements could be rearranged as well.
![image](https://user-images.githubusercontent.com/3487395/169624551-3c79348e-e4b1-425b-8ee6-d3deccbf0f07.png)

Additionally the ROI display is hardcoded to be colored more neutral with an empty fill as described in https://github.com/Project-MONAI/MONAILabel/issues/422#issuecomment-927141895
![image](https://user-images.githubusercontent.com/3487395/169624449-28e3fbe3-c56e-4424-a563-a72bec3654e6.png)

cc @masadcv 