### PR TITLE
Fix hang in Slicer plugin when loading next sample

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1227,7 +1227,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     originalNode = sampleDataLogic.downloadFromURL(
                         nodeNames="segmentation_" + image_id,
                         loadFileTypes="SegmentationFile",
-                        fileNames=image_name,
+                        fileNames="segmentation_" + image_name,
                         uris=download_uri,
                         checksums=checksum,
                     )[0]


### PR DESCRIPTION
Using the radiology application with the spleen data set (as described [here](https://github.com/Project-MONAI/MONAILabel#development-version)).
I connected successfully, then clicked on "Next sample". Slicer displayed the CT but then froze. Debugged into it and the problem was that Slicer loaded and tried to process a "segmentation" with 2000 labels, which took really long time (many minutes? I did not wait for it to end).

The "segmentation" was actually the grayscale image. The issue was that an existing filename was specified (the same as for the CT image) and no checksum value was set, so Slicer just reused the existing cached file instead of attempting to download it again.

As a quick fix I've modified the label filename to be different from the image filename, but there is still no guarantee that there will be no old files in the cache by that name.

Options for proper solutions include:
- always specify hash (e.g., sha256) for downloads
- always force re-download when hash is not available
- use HTTP protocol's cache invalidation mechanisms to determine if a previously downloaded file can be reused