### PR TITLE
Fix segmentation model for single label segmentation

### DIFF
--- a/sample-apps/radiology/lib/configs/segmentation.py
+++ b/sample-apps/radiology/lib/configs/segmentation.py
@@ -46,6 +46,9 @@ class Segmentation(TaskConfig):
             "left adrenal gland": 13,
         }
 
+        # Number of input channels - 4 for BRATS and 1 for spleen
+        self.number_intensity_ch = 1
+
         # Model Files
         self.path = [
             os.path.join(self.model_dir, f"pretrained_{name}.pt"),  # pretrained
@@ -64,7 +67,7 @@ class Segmentation(TaskConfig):
         # Network
         self.network = UNet(
             spatial_dims=3,
-            in_channels=1,
+            in_channels=self.number_intensity_ch,
             out_channels=len(self.labels.keys()) + 1,  # All labels plus background
             channels=[16, 32, 64, 128, 256],
             strides=[2, 2, 2, 2],

--- a/sample-apps/radiology/lib/infers/segmentation.py
+++ b/sample-apps/radiology/lib/infers/segmentation.py
@@ -71,8 +71,8 @@ class Segmentation(InferTask):
         applied_labels = list(self.labels.values()) if isinstance(self.labels, dict) else self.labels
         t = [
             EnsureTyped(keys="pred", device=data.get("device") if data else None),
-            Activationsd(keys="pred", softmax=len(self.labels) > 1, sigmoid=len(self.labels) == 1),
-            AsDiscreted(keys="pred", argmax=len(self.labels) > 1, threshold=0.5 if len(self.labels) == 1 else None),
+            Activationsd(keys="pred", softmax=True),
+            AsDiscreted(keys="pred", argmax=True),
         ]
         if largest_cc:
             t.append(KeepLargestConnectedComponentd(keys="pred", applied_labels=applied_labels))


### PR DESCRIPTION
Signed-off-by: Andres Diaz-Pinto <diazandr3s@gmail.com>

When using the segmentation model for single label segmentation, the length of the labels dictionary is not bigger than 1. But the number of output channels in the architecture is 2 ... Output predictions are corrupted files.

- Added options for training brats dataset using the segmentation model

Thanks for reporting this issue @dgmato