### PR TITLE
Support preload flag for radiology + gpu transform for segmentation models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ watchdog==2.1.6
 pydantic==1.9.0
 python-dotenv==0.19.2
 filelock==3.4.2
-httpx==0.22.0
+httpx==0.23.0
 dicomweb-client==0.52.0
 pydicom==2.2.2
 pydicom-seg==0.4.0

--- a/sample-apps/radiology/README.md
+++ b/sample-apps/radiology/README.md
@@ -42,10 +42,13 @@ monailabel apps --download --name radiology --output workspace
 monailabel start_server --app workspace/radiology --studies workspace/images --conf models deepedit
 
 # Pick Deepgrow And Segmentation model (multiple models)
-monailabel start_server --app workspace/radiology --studies workspace/images --conf models deepgrow_2d,deepgrow_3d,segmentation
+monailabel start_server --app workspace/radiology --studies workspace/images --conf models "deepgrow_2d,deepgrow_3d,segmentation"
 
 # Pick All
 monailabel start_server --app workspace/radiology --studies workspace/images --conf models all
+
+# Pick All + Preload into All GPU devices
+monailabel start_server --app workspace/radiology --studies workspace/images --conf models all --conf preload true
 
 # Pick All (Skip Training Tasks or Infer only mode)
 monailabel start_server --app workspace/radiology --studies workspace/images --conf models all --conf skip_trainers true
@@ -74,6 +77,7 @@ This model works for single and multiple label segmentation tasks.
 | epistemic_samples    | int                | Limit number of samples to run epistemic scoring                   |
 | tta_enabled          | true, **false**    | Enable TTA (Test Time Augmentation) based Active Learning Strategy |
 | tta_samples          | int                | Limit number of samples to run tta scoring                         |
+| preload              | true, **false**    | Preload model into GPU                                                                                |
 
 A command example to use active learning strategies with DeepEdit would be:
 
@@ -125,7 +129,10 @@ the model to learn on new organ.
 > monailabel start_server --app workspace/radiology --studies workspace/images --conf models deepgrow_2d,deepgrow_3d
 
 - Additional Configs *(pass them as **--conf name value**) while starting MONAILabelServer*
-  > None
+
+| Name                 | Values             | Description                                                     |
+|----------------------|--------------------|-----------------------------------------------------------------|
+| preload              | true, **false**    | Preload model into GPU                                                                                |
 
 - Network
   > This App uses the [BasicUNet](https://docs.monai.io/en/latest/networks.html#basicunet) as the default network.
@@ -169,7 +176,8 @@ This model based on UNet for automated segmentation. This model works for single
 
 | Name                 | Values             | Description                                                     |
 |----------------------|--------------------|-----------------------------------------------------------------|
-| use_pretrained_model | **true**, false        | Disable this NOT to load any pretrained weights                 |
+| use_pretrained_model | **true**, false    | Disable this NOT to load any pretrained weights                 |
+| preload              | true, **false**    | Preload model into GPU                                                                                |
 
 - Network
   > This App uses the [UNet](https://docs.monai.io/en/latest/networks.html#unet) as the default network.
@@ -222,6 +230,7 @@ from [NVIDIA Clara](https://catalog.ngc.nvidia.com/models?filters=&orderBy=dateM
 | epistemic_samples    | int             | Limit number of samples to run epistemic scoring                   |
 | tta_enabled          | true, **false** | Enable TTA (Test Time Augmentation) based Active Learning Strategy |
 | tta_samples          | int             | Limit number of samples to run tta scoring                         |
+| preload              | true, **false** | Preload model into GPU                                                                                |
 
 
 A command example to use active learning strategies with segmentation_spleen would be:

--- a/sample-apps/radiology/lib/configs/deepedit.py
+++ b/sample-apps/radiology/lib/configs/deepedit.py
@@ -125,12 +125,17 @@ class DeepEdit(TaskConfig):
     def infer(self) -> Union[InferTask, Dict[str, InferTask]]:
         return {
             self.name: lib.infers.DeepEdit(
-                path=self.path, network=self.network, labels=self.labels, spatial_size=self.spatial_size
+                path=self.path,
+                network=self.network,
+                labels=self.labels,
+                preload=strtobool(self.conf.get("preload", "false")),
+                spatial_size=self.spatial_size,
             ),
             f"{self.name}_seg": lib.infers.DeepEdit(
                 path=self.path,
                 network=self.network,
                 labels=self.labels,
+                preload=strtobool(self.conf.get("preload", "false")),
                 spatial_size=self.spatial_size,
                 number_intensity_ch=self.number_intensity_ch,
                 type=InferType.SEGMENTATION,

--- a/sample-apps/radiology/lib/configs/deepgrow_2d.py
+++ b/sample-apps/radiology/lib/configs/deepgrow_2d.py
@@ -67,7 +67,12 @@ class Deepgrow2D(TaskConfig):
         )
 
     def infer(self) -> Union[InferTask, Dict[str, InferTask]]:
-        task: InferTask = lib.infers.Deepgrow(path=self.path, network=self.network, labels=self.labels)
+        task: InferTask = lib.infers.Deepgrow(
+            path=self.path,
+            network=self.network,
+            labels=self.labels,
+            preload=strtobool(self.conf.get("preload", "false")),
+        )
         return task
 
     def trainer(self) -> Optional[TrainTask]:

--- a/sample-apps/radiology/lib/configs/deepgrow_3d.py
+++ b/sample-apps/radiology/lib/configs/deepgrow_3d.py
@@ -71,6 +71,7 @@ class Deepgrow3D(TaskConfig):
             path=self.path,
             network=self.network,
             labels=self.labels,
+            preload=strtobool(self.conf.get("preload", "false")),
             dimension=3,
             model_size=(128, 192, 192),
         )

--- a/sample-apps/radiology/lib/configs/segmentation.py
+++ b/sample-apps/radiology/lib/configs/segmentation.py
@@ -82,7 +82,8 @@ class Segmentation(TaskConfig):
             roi_size=self.roi_size,
             target_spacing=self.target_spacing,
             labels=self.labels,
-            config={"largest_cc": True},
+            preload=strtobool(self.conf.get("preload", "false")),
+            config={"largest_cc": False},
         )
         return task
 

--- a/sample-apps/radiology/lib/configs/segmentation_spleen.py
+++ b/sample-apps/radiology/lib/configs/segmentation_spleen.py
@@ -81,7 +81,10 @@ class SegmentationSpleen(TaskConfig):
 
     def infer(self) -> Union[InferTask, Dict[str, InferTask]]:
         task: InferTask = lib.infers.SegmentationSpleen(
-            path=self.path, network=self.network, labels=self.labels, preload=False
+            path=self.path,
+            network=self.network,
+            labels=self.labels,
+            preload=strtobool(self.conf.get("preload", "false")),
         )
         return task
 

--- a/sample-apps/radiology/lib/infers/deepedit.py
+++ b/sample-apps/radiology/lib/infers/deepedit.py
@@ -51,6 +51,7 @@ class DeepEdit(InferTask):
         target_spacing=(1.0, 1.0, 1.0),
         number_intensity_ch=1,
         description="A DeepEdit model for volumetric (3D) segmentation over 3D Images",
+        **kwargs,
     ):
         super().__init__(
             path=path,
@@ -62,6 +63,7 @@ class DeepEdit(InferTask):
             input_key="image",
             output_label_key="pred",
             output_json_key="result",
+            **kwargs,
         )
 
         self.spatial_size = spatial_size

--- a/sample-apps/radiology/lib/infers/deepgrow.py
+++ b/sample-apps/radiology/lib/infers/deepgrow.py
@@ -52,6 +52,7 @@ class Deepgrow(InferTask):
         description="A pre-trained DeepGrow model based on UNET",
         spatial_size=(256, 256),
         model_size=(256, 256),
+        **kwargs,
     ):
         super().__init__(
             path=path,
@@ -60,6 +61,7 @@ class Deepgrow(InferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            **kwargs,
         )
 
         self.spatial_size = spatial_size

--- a/sample-apps/radiology/lib/infers/segmentation_spleen.py
+++ b/sample-apps/radiology/lib/infers/segmentation_spleen.py
@@ -54,10 +54,10 @@ class SegmentationSpleen(InferTask):
     def pre_transforms(self, data=None) -> Sequence[Callable]:
         return [
             LoadImaged(keys="image"),
+            EnsureTyped(keys="image", device=data.get("device") if data else None),
             EnsureChannelFirstd(keys="image"),
             Spacingd(keys="image", pixdim=[1.0, 1.0, 1.0]),
             ScaleIntensityRanged(keys="image", a_min=-57, a_max=164, b_min=0.0, b_max=1.0, clip=True),
-            EnsureTyped(keys="image"),
         ]
 
     def inferer(self, data=None) -> Inferer:


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

- Fix security warning for httpx package upgrade
- Support preload flag
- Enable GPU for possible pre-transform for segmentation and segmentation_spleen models
- Largest CC flag set to false (which takes more time for segmentation model as there are 8+ labels; let use choose from options)

Following is the improvement when running all pre-transform in GPU

```
++ Latencies => Total: 2.4321; Pre: 1.0516; Inferer: 0.3512; Invert: 0.0000; Post: 0.1197; Write: 0.9086
++ Latencies => Total: 2.2475; Pre: 0.8852; Inferer: 0.3185; Invert: 0.0000; Post: 0.1226; Write: 0.9209

++ Latencies => Total: 10.0143; Pre: 6.0249; Inferer: 1.3133; Invert: 0.0000; Post: 0.3525; Write: 2.3230
++ Latencies => Total: 4.9907; Pre: 1.0041; Inferer: 1.4217; Invert: 0.0000; Post: 0.3380; Write: 2.2264

++ Latencies => Total: 8.9291; Pre: 6.4562; Inferer: 1.1783; Invert: 0.0000; Post: 0.5676; Write: 0.7264
++ Latencies => Total: 3.5018; Pre: 1.1196; Inferer: 1.3348; Invert: 0.0000; Post: 0.3471; Write: 0.6997
```
