### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -46,7 +46,7 @@ Install MONAI Label Plugin in 3DSlicer
 
 Install 3DSlicer Preview Version with in-built MONAI Label plugin
 
-- Download and Install `3D Slicer <https://download.slicer.org/>`_ and choose one of the download links under **Preview Release**
+- Download and Install `3D Slicer <https://download.slicer.org/>`_ version 5.0 or later.
 - Start 3DSlicer
 - On the menu bar navigate **View** -> **Extension Manager** -> **Active Learning** -> **MONAI Label**
 


### PR DESCRIPTION
MONAILabel is available in the Slicer Stable Release (5.0.x) now and so there is no need to use the Slicer Preview Releases anymore.