### PR TITLE
Do not truncate node_name

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1203,7 +1203,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             image_id = sample["id"]
             image_file = sample.get("path")
             image_name = sample.get("name", image_id)
-            node_name = sample.get("PatientID", sample.get("name", image_id))[-20:]
+            node_name = sample.get("PatientID", sample.get("name", image_id))
             checksum = sample.get("checksum")
             local_exists = image_file and os.path.exists(image_file)
 


### PR DESCRIPTION
Store node name in full to allow individual elements to truncate it as needed. PR #841 elides text in the 'Master Volume:' dropdown.
Note: on testing, the elided node name appears in slice view, but the dropdown text still appears full length, or at least longer than that in the slice view.