### PR TITLE
Add basic auth with roles [admin, reviewer, annotator, user]

### DIFF
--- a/monailabel/app.py
+++ b/monailabel/app.py
@@ -26,6 +26,7 @@ from monailabel.endpoints import (
     datastore,
     infer,
     info,
+    login,
     logs,
     ohif,
     proxy,
@@ -62,6 +63,7 @@ app.mount(
     name="static",
 )
 
+app.include_router(login.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(info.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(infer.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(wsi_infer.router, prefix=settings.MONAI_LABEL_API_STR)

--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
 
     MONAI_LABEL_APP_DIR: str = ""
     MONAI_LABEL_STUDIES: str = ""
+    MONAI_LABEL_AUTH_ENABLE: bool = False
+    MONAI_LABEL_AUTH_DB: str = ""
     MONAI_LABEL_APP_CONF: Dict[str, str] = {}
 
     MONAI_LABEL_TASKS_TRAIN: bool = True

--- a/monailabel/endpoints/activelearning.py
+++ b/monailabel/endpoints/activelearning.py
@@ -49,7 +49,7 @@ def sample(strategy: str, params: Optional[dict] = None, user: Optional[str] = N
     image_info = instance.datastore().get_image_info(image_id)
 
     strategy_info = image_info.get("strategy", {})
-    strategy_info[strategy] = {"ts": int(time.time()), "client_id": user if user else params.get("client_id")}
+    strategy_info[strategy] = {"ts": int(time.time()), "client_id": params.get("client_id", user)}
     instance.datastore().update_image_info(image_id, {"strategy": strategy_info})
 
     result = {

--- a/monailabel/endpoints/batch_infer.py
+++ b/monailabel/endpoints/batch_infer.py
@@ -13,8 +13,9 @@ import logging
 from typing import Optional
 
 import torch
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from monailabel.endpoints.user.auth import User, get_annotator_user
 from monailabel.interfaces.tasks.batch_infer import BatchInferImageType
 from monailabel.utils.async_tasks.task import AsyncTask
 
@@ -57,7 +58,7 @@ def stop():
 
 
 @router.get("/infer", summary="Get Status of Batch Inference Task")
-async def api_status(all: bool = False, check_if_running: bool = False):
+async def api_status(all: bool = False, check_if_running: bool = False, user: User = Depends(get_annotator_user)):
     return status(all, check_if_running)
 
 
@@ -67,10 +68,11 @@ async def api_run(
     images: Optional[BatchInferImageType] = BatchInferImageType.IMAGES_ALL,
     params: Optional[dict] = None,
     run_sync: Optional[bool] = False,
+    user: User = Depends(get_annotator_user),
 ):
     return run(model, images, params, run_sync)
 
 
 @router.delete("/infer", summary="Stop Batch Inference Task")
-async def api_stop():
+async def api_stop(user: User = Depends(get_annotator_user)):
     return stop()

--- a/monailabel/endpoints/datastore.py
+++ b/monailabel/endpoints/datastore.py
@@ -18,10 +18,11 @@ import tempfile
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse
 
+from monailabel.endpoints.user.auth import User, get_admin_user, get_annotator_user, get_basic_user, get_reviwer_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.datastore import Datastore, DefaultLabelTag
 from monailabel.interfaces.utils.app import app_instance
@@ -61,6 +62,7 @@ def add_image(
     image: Optional[str] = None,
     params: str = Form("{}"),
     file: UploadFile = File(...),
+    user: Optional[str] = None,
 ):
     logger.info(f"Image: {image}; File: {file}; params: {params}")
     file_ext = "".join(pathlib.Path(file.filename).suffixes) if file.filename else ".nii.gz"
@@ -74,11 +76,14 @@ def add_image(
 
     instance: MONAILabelApp = app_instance()
     save_params: Dict[str, Any] = json.loads(params) if params else {}
+    if user:
+        save_params["user"] = user
     image_id = instance.datastore().add_image(image_id, image_file, save_params)
     return {"image": image_id}
 
 
-def remove_image(id: str):
+def remove_image(id: str, user: Optional[str] = None):
+    logger.info(f"Removing Image: {id} by {user}")
     instance: MONAILabelApp = app_instance()
     instance.datastore().remove_image(id)
     return {}
@@ -90,7 +95,9 @@ def save_label(
     params: str = Form("{}"),
     tag: str = DefaultLabelTag.FINAL.value,
     label: UploadFile = File(...),
+    user: Optional[str] = None,
 ):
+    logger.info(f"Saving Label for {image} for tag: {tag} by {user}")
     file_ext = "".join(pathlib.Path(label.filename).suffixes) if label.filename else ".nii.gz"
     label_file = tempfile.NamedTemporaryFile(suffix=file_ext).name
     tag = tag if tag else DefaultLabelTag.FINAL.value
@@ -115,7 +122,8 @@ def save_label(
     return res
 
 
-def remove_label(id: str, tag: str):
+def remove_label(id: str, tag: str, user: Optional[str] = None):
+    logger.info(f"Removing Label: {id} by {user}")
     instance: MONAILabelApp = app_instance()
     instance.datastore().remove_label(id, tag)
     return {}
@@ -139,8 +147,38 @@ def download_label(label: str, tag: str):
     return FileResponse(label, media_type=get_mime_type(label), filename=os.path.basename(label))
 
 
+def get_image_info(image: str):
+    instance: MONAILabelApp = app_instance()
+    return instance.datastore().get_image_info(image)
+
+
+def update_image_info(image: str, info: str = Form("{}"), user: Optional[str] = None):
+    logger.info(f"Update Image Info: {image} by {user}")
+
+    instance: MONAILabelApp = app_instance()
+    i = json.loads(info)
+    if user:
+        i["user"] = user
+    return instance.datastore().update_image_info(image, i)
+
+
+def get_label_info(label: str, tag: str):
+    instance: MONAILabelApp = app_instance()
+    return instance.datastore().get_label_info(label, tag)
+
+
+def update_label_info(label: str, tag: str, info: str = Form("{}"), user: Optional[str] = None):
+    logger.info(f"Update Label Info: {label} for {tag} by {user}")
+
+    instance: MONAILabelApp = app_instance()
+    i = json.loads(info)
+    if user:
+        i["user"] = user
+    return instance.datastore().update_label_info(label, tag, i)
+
+
 @router.get("/", summary="Get All Images/Labels from datastore")
-async def api_datastore(output: Optional[ResultType] = None):
+async def api_datastore(output: Optional[ResultType] = None, user: User = Depends(get_basic_user)):
     return datastore(output)
 
 
@@ -150,13 +188,14 @@ async def api_add_image(
     image: Optional[str] = None,
     params: str = Form("{}"),
     file: UploadFile = File(...),
+    user: User = Depends(get_annotator_user),
 ):
-    return add_image(background_tasks, image, params, file)
+    return add_image(background_tasks, image, params, file, user.username)
 
 
 @router.delete("/", summary="Remove Image and corresponding labels")
-async def api_remove_image(id: str):
-    return remove_image(id)
+async def api_remove_image(id: str, user: User = Depends(get_admin_user)):
+    return remove_image(id, user.username)
 
 
 @router.put("/label", summary="Save Finished Label")
@@ -166,31 +205,53 @@ async def api_save_label(
     params: str = Form("{}"),
     tag: str = DefaultLabelTag.FINAL.value,
     label: UploadFile = File(...),
+    user: User = Depends(get_annotator_user),
 ):
-    return save_label(background_tasks, image, params, tag, label)
+    return save_label(background_tasks, image, params, tag, label, user.username)
 
 
 @router.delete("/label", summary="Remove Label")
-async def api_remove_label(id: str, tag: str):
-    return remove_label(id, tag)
+async def api_remove_label(id: str, tag: str, user: User = Depends(get_reviwer_user)):
+    return remove_label(id, tag, user.username)
 
 
 @router.get("/image", summary="Download Image")
-async def api_download_image(image: str):
+async def api_download_image(image: str, user: User = Depends(get_basic_user)):
     return download_image(image)
 
 
+@router.get("/image/info", summary="Get Image Info")
+async def api_get_image_info(image: str, user: User = Depends(get_basic_user)):
+    return get_image_info(image)
+
+
+@router.put("/image/info", summary="Update Image Info")
+async def api_put_image_info(image: str, info: str = Form("{}"), user: User = Depends(get_annotator_user)):
+    return update_image_info(image, info, user.username)
+
+
 @router.get("/label", summary="Download Label")
-async def api_download_label(label: str, tag: str):
+async def api_download_label(label: str, tag: str, user: User = Depends(get_basic_user)):
     return download_label(label, tag)
 
 
+@router.get("/label/info", summary="Get Label Info")
+async def api_get_label_info(label: str, tag: str, user: User = Depends(get_basic_user)):
+    return get_label_info(label, tag)
+
+
+@router.put("/label/info", summary="Update Label Info")
+async def api_put_label_info(label: str, tag: str, info: str = Form("{}"), user: User = Depends(get_annotator_user)):
+    return update_label_info(label, tag, info, user.username)
+
+
+# This shall be deprecated and use above ones to update the label info
 @router.put("/updatelabelinfo", summary="Update label info")
-async def api_update_label_info(label: str, params: str = Form("{}")):
-    return update_label_info(label, params)
+async def api_update_label_info(label: str, params: str = Form("{}"), user: User = Depends(get_annotator_user)):
+    return update_label_info_deprecated(label, params)
 
 
-def update_label_info(label_id: str, params: str = Form("{}")):
+def update_label_info_deprecated(label_id: str, params: str = Form("{}")):
     save_params: Dict[str, Any] = json.loads(params) if params else {}
     instance: MONAILabelApp = app_instance()
     instance.datastore().update_label_info(label_id=label_id, label_tag="final", info=save_params)

--- a/monailabel/endpoints/infer.py
+++ b/monailabel/endpoints/infer.py
@@ -18,12 +18,13 @@ import tempfile
 from enum import Enum
 from typing import Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse, Response
 from requests_toolbelt import MultipartEncoder
 
 from monailabel.datastore.utils.convert import binary_to_image
+from monailabel.endpoints.user.auth import User, get_basic_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.others.generic import get_mime_type, remove_file
@@ -173,5 +174,6 @@ async def api_run_inference(
     file: UploadFile = File(None),
     label: UploadFile = File(None),
     output: Optional[ResultType] = None,
+    user: User = Depends(get_basic_user),
 ):
     return run_inference(background_tasks, model, image, session_id, params, file, label, output)

--- a/monailabel/endpoints/info.py
+++ b/monailabel/endpoints/info.py
@@ -9,8 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from monailabel.endpoints.user.auth import User, get_basic_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 
@@ -27,5 +28,5 @@ def app_info():
 
 
 @router.get("/", summary="Get App Info")
-async def api_app_info():
+async def api_app_info(user: User = Depends(get_basic_user)):
     return app_info()

--- a/monailabel/endpoints/login.py
+++ b/monailabel/endpoints/login.py
@@ -1,0 +1,45 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+
+from monailabel.endpoints.user.auth import ACCESS_TOKEN_EXPIRE_MINUTES, Token, authenticate_user, create_access_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="",
+    tags=["AppService"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.post("/token", response_model=Token)
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    logger.info(f"User: {user.username}; Scopes: {user.scopes}")
+
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={
+            "sub": user.username,
+            "scopes": user.scopes,
+        },
+        expires_delta=access_token_expires,
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/monailabel/endpoints/logs.py
+++ b/monailabel/endpoints/logs.py
@@ -14,10 +14,11 @@ import subprocess
 from collections import deque
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse, Response
 
 from monailabel.config import settings
+from monailabel.endpoints.user.auth import User, get_basic_user
 
 router = APIRouter(
     prefix="/logs",
@@ -93,11 +94,12 @@ async def api_get_logs(
     html: Optional[bool] = True,
     text: Optional[bool] = False,
     refresh: Optional[int] = 0,
+    user: User = Depends(get_basic_user),
 ):
     return get_logs(os.path.join(settings.MONAI_LABEL_APP_DIR, "logs", "app.log"), lines, html, text, refresh)
 
 
 @router.get("/gpu", summary="Get GPU Info (nvidia-smi)")
-async def gpu_info():
+async def gpu_info(user: User = Depends(get_basic_user)):
     response = subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE).stdout.decode("utf-8")
     return Response(content=response, media_type="text/plain")

--- a/monailabel/endpoints/ohif.py
+++ b/monailabel/endpoints/ohif.py
@@ -1,9 +1,10 @@
 import logging
 import os
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 
+from monailabel.endpoints.user.auth import User, get_basic_user
 from monailabel.utils.others.generic import get_mime_type
 
 logger = logging.getLogger(__name__)
@@ -29,5 +30,5 @@ def get_ohif(path: str):
 
 
 @router.get("/{path:path}", include_in_schema=False)
-async def api_get_ohif(path: str):
+async def api_get_ohif(path: str, user: User = Depends(get_basic_user)):
     return get_ohif(path)

--- a/monailabel/endpoints/proxy.py
+++ b/monailabel/endpoints/proxy.py
@@ -1,10 +1,11 @@
 import logging
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 
 from monailabel.config import settings
+from monailabel.endpoints.user.auth import User, get_basic_user
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ router = APIRouter(
 
 
 @router.get("/dicom/{path:path}", include_in_schema=False)
-async def proxy(path: str, response: Response):
+async def proxy(path: str, response: Response, user: User = Depends(get_basic_user)):
     auth = (
         (settings.MONAI_LABEL_DICOMWEB_USERNAME, settings.MONAI_LABEL_DICOMWEB_PASSWORD)
         if settings.MONAI_LABEL_DICOMWEB_USERNAME and settings.MONAI_LABEL_DICOMWEB_PASSWORD

--- a/monailabel/endpoints/scoring.py
+++ b/monailabel/endpoints/scoring.py
@@ -13,8 +13,9 @@ import logging
 from typing import Optional
 
 import torch
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from monailabel.endpoints.user.auth import User, get_annotator_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.async_tasks.task import AsyncTask
@@ -64,20 +65,33 @@ def stop():
 
 
 @router.get("/", summary="Get Status of Scoring Task")
-async def api_status(all: bool = False, check_if_running: bool = False):
+async def api_status(
+    all: bool = False,
+    check_if_running: bool = False,
+    user: User = Depends(get_annotator_user),
+):
     return status(all, check_if_running)
 
 
 @router.post("/", summary="Run All Scoring Tasks")
-async def api_run(params: Optional[dict] = None, run_sync: Optional[bool] = False):
+async def api_run(
+    params: Optional[dict] = None,
+    run_sync: Optional[bool] = False,
+    user: User = Depends(get_annotator_user),
+):
     return run(params, run_sync)
 
 
 @router.post("/{method}", summary="Run Scoring Task for specific method")
-async def api_run_method(method: str, params: Optional[dict] = None, run_sync: Optional[bool] = False):
+async def api_run_method(
+    method: str,
+    params: Optional[dict] = None,
+    run_sync: Optional[bool] = False,
+    user: User = Depends(get_annotator_user),
+):
     return run_method(method, params, run_sync)
 
 
 @router.delete("/", summary="Stop Scoring Task")
-async def api_stop():
+async def api_stop(user: User = Depends(get_annotator_user)):
     return stop()

--- a/monailabel/endpoints/session.py
+++ b/monailabel/endpoints/session.py
@@ -14,10 +14,11 @@ import shutil
 import tempfile
 from typing import List
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse
 
+from monailabel.endpoints.user.auth import User, get_basic_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.others.generic import get_basename, get_mime_type, remove_file
@@ -109,7 +110,12 @@ def remove_session(session_id: str):
 
 
 @router.get("/{session_id}", summary="Get Session ID")
-async def api_get_session(session_id: str, update_ts: bool = False, image: bool = False):
+async def api_get_session(
+    session_id: str,
+    update_ts: bool = False,
+    image: bool = False,
+    user: User = Depends(get_basic_user),
+):
     return get_session(session_id, update_ts, image)
 
 
@@ -119,10 +125,11 @@ async def api_create_session(
     uncompress: bool = False,
     expiry: int = 0,
     files: List[UploadFile] = File(...),
+    user: User = Depends(get_basic_user),
 ):
     return create_session(background_tasks, uncompress, expiry, files)
 
 
 @router.delete("/{session_id}", summary="Delete Session")
-async def api_remove_session(session_id: str):
+async def api_remove_session(session_id: str, user: User = Depends(get_basic_user)):
     return remove_session(session_id)

--- a/monailabel/endpoints/train.py
+++ b/monailabel/endpoints/train.py
@@ -13,8 +13,9 @@ import logging
 from typing import Optional
 
 import torch
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from monailabel.endpoints.user.auth import User, get_admin_user, get_basic_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.async_tasks.task import AsyncTask
@@ -67,22 +68,34 @@ def stop():
 
 
 @router.get("/", summary="Get Status of Training Task")
-async def api_status(all: bool = False, check_if_running: bool = False):
+async def api_status(
+    all: bool = False,
+    check_if_running: bool = False,
+    user: User = Depends(get_basic_user),
+):
     return status(all, check_if_running)
 
 
 @router.post("/", summary="Run All Training Tasks")
-async def api_run(params: Optional[dict] = None, run_sync: Optional[bool] = False):
+async def api_run(
+    params: Optional[dict] = None,
+    run_sync: Optional[bool] = False,
+    user: User = Depends(get_admin_user),
+):
     return run(params, run_sync)
 
 
 @router.post("/{model}", summary="Run Training Task for specific model")
 async def api_run_model(
-    model: str, params: Optional[dict] = None, run_sync: Optional[bool] = False, enqueue: Optional[bool] = False
+    model: str,
+    params: Optional[dict] = None,
+    run_sync: Optional[bool] = False,
+    enqueue: Optional[bool] = False,
+    user: User = Depends(get_admin_user),
 ):
     return run_model(model, params, run_sync, enqueue)
 
 
 @router.delete("/", summary="Stop Training Task")
-async def api_stop():
+async def api_stop(user: User = Depends(get_admin_user)):
     return stop()

--- a/monailabel/endpoints/user/auth.py
+++ b/monailabel/endpoints/user/auth.py
@@ -1,0 +1,168 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from datetime import datetime, timedelta
+from typing import List, Union
+
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import OAuth2PasswordBearer, SecurityScopes
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from pydantic import BaseModel, ValidationError
+
+from monailabel.config import settings
+
+# openssl rand -hex 32
+SECRET_KEY = "c1d2508874b7774026272647cd1d2c0471a9e81d949a0f3a85abe413eb2a95a0"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+scopes = {
+    "admin": "Who can run training and everything...",
+    "reviewer": "Who can validate and modify saved annotations etc..",
+    "annotator": "Who can annotate and submit labels",
+    "user": "Annotator who cannot submit labels",
+}
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenData(BaseModel):
+    username: str = ""
+    scopes: List[str] = []
+
+
+class User(BaseModel):
+    username: str
+    email: Union[str, None] = None
+    full_name: Union[str, None] = None
+    disabled: Union[bool, None] = None
+    scopes: List[str] = []
+
+
+class UserInDB(User):
+    hashed_password: str
+
+
+def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(
+    security_scopes: SecurityScopes, token: str = Depends(oauth2_scheme) if settings.MONAI_LABEL_AUTH_ENABLE else ""
+):
+    if not settings.MONAI_LABEL_AUTH_ENABLE:
+        return get_user(username="admin")
+
+    if security_scopes.scopes:
+        authenticate_value = f'Bearer scope="{security_scopes.scope_str}"'
+    else:
+        authenticate_value = "Bearer"
+
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": authenticate_value},
+    )
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_scopes = payload.get("scopes", [])
+        token_data = TokenData(scopes=token_scopes, username=username)
+    except (JWTError, ValidationError):
+        raise credentials_exception
+
+    user = get_user(token_data.username)
+    if user is None:
+        raise credentials_exception
+
+    for scope in security_scopes.scopes:
+        if scope not in token_data.scopes:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not enough permissions",
+                headers={"WWW-Authenticate": authenticate_value},
+            )
+    return user
+
+
+async def get_admin_user(current_user: User = Security(get_current_user, scopes=["admin"])):
+    if current_user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+async def get_reviwer_user(current_user: User = Security(get_current_user, scopes=["reviewer"])):
+    if current_user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+async def get_annotator_user(current_user: User = Security(get_current_user, scopes=["annotator"])):
+    if current_user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+async def get_basic_user(current_user: User = Security(get_current_user, scopes=["user"])):
+    if current_user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def get_user(username: str):
+    f = settings.MONAI_LABEL_AUTH_DB
+    if not f:
+        f = os.path.join(os.path.dirname(os.path.realpath(__file__)), "users.json")
+
+    db = {}
+    if os.path.exists(f):
+        with open(f) as fp:
+            db = json.load(fp)
+
+    if username in db:
+        user_dict = db[username]
+        return UserInDB(**user_dict)
+    return None
+
+
+def authenticate_user(username: str, password: str):
+    user = get_user(username)
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user

--- a/monailabel/endpoints/user/users.json
+++ b/monailabel/endpoints/user/users.json
@@ -1,0 +1,48 @@
+{
+  "admin": {
+    "username": "admin",
+    "full_name": "Admin",
+    "email": "admin@monailabel.com",
+    "hashed_password": "$2b$12$CexVjWGTX//w8kt.f3CbGuznFtnlHCVte1EUScwzDCRKMRmltGBDa",
+    "disabled": false,
+    "scopes": [
+      "admin",
+      "reviewer",
+      "annotator",
+      "user"
+    ]
+  },
+  "reviewer": {
+    "username": "reviewer",
+    "full_name": "Reviewer",
+    "email": "reviewer@monailabel.com",
+    "hashed_password": "$2b$12$KJzEvm8iQFOwiLLecBjxg./g/9XLt1VMIDBrEFqJnqEOonxaWZ1y2",
+    "disabled": false,
+    "scopes": [
+      "reviewer",
+      "annotator",
+      "user"
+    ]
+  },
+  "annotator": {
+    "username": "annotator",
+    "full_name": "Annotator",
+    "email": "annotator@monailabel.com",
+    "hashed_password": "$2b$12$6RPP.jL.8GZmP7DtJhWRLO.Exvh6LGUleXq.KLyBv9/leoV8KY8Pm",
+    "disabled": false,
+    "scopes": [
+      "annotator",
+      "user"
+    ]
+  },
+  "user": {
+    "username": "user",
+    "full_name": "User",
+    "email": "user@monailabel.com",
+    "hashed_password": "$2b$12$Py6rSaJyhJIYfgnEOmCzLuQ9Kz7FtMdzjRCimtPUmPspbIPbRH6Dq",
+    "disabled": false,
+    "scopes": [
+      "user"
+    ]
+  }
+}

--- a/monailabel/endpoints/wsi_infer.py
+++ b/monailabel/endpoints/wsi_infer.py
@@ -14,11 +14,12 @@ import os
 from enum import Enum
 from typing import Optional, Sequence
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
+from monailabel.endpoints.user.auth import User, get_basic_user
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.others.generic import get_mime_type, remove_file
@@ -107,5 +108,6 @@ async def api_run_wsi_inference(
     session_id: str = "",
     wsi: WSIInput = WSIInput(),
     output: Optional[ResultType] = None,
+    user: User = Depends(get_basic_user),
 ):
     return run_wsi_inference(background_tasks, model, image, session_id, wsi, output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,8 @@ ninja==1.10.2.3
 einops>=0.3.2
 PyYAML==6.0
 filelock==3.7.1
+passlib==1.7.4
+python-jose[cryptography]==3.3.0
+bcrypt==3.2.2
 
 #sudo apt-get install openslide-tools -y

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,9 @@ install_requires =
     einops>=0.3.2
     PyYAML==6.0
     filelock==3.7.1
+    passlib==1.7.4
+    python-jose[cryptography]==3.3.0
+    bcrypt==3.2.2
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9


### PR DESCRIPTION
Signed-off-by: SACHIDANAND ALLE <sachidanand.alle@gmail.com>

This shall be only the first draft.. that can support following 4 different scopes/roles/access management
- admin (can do everything)
- reviewer (admin minus can not delete images; however can delete saved labels)
- annotator ( reviewer minus cannot delete labels)
- user (can only run basic inference and related activities without submitting/modifying anything back in server)

By default the feature is disabled, and you can enable it by running
`export MONAI_LABEL_AUTH_ENABLE=True`

and then start monailabel server.

In the next draft, we can have corresponding changes in 3D slicer/client plugins 