### PR TITLE
update `monailabel/scribbles/infer.py`

### DIFF
--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -112,6 +112,7 @@ class ScribblesLikelihoodInferTask(InferTask):
                 lamda=self.lamda,
                 sigma=self.sigma,
             ),
+            FromMetaTensord(keys=["image"]),
             Restored(keys="pred", ref_image="image"),
             BoundingBoxd(keys="pred", result="result", bbox="bbox"),
         ]

--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -9,7 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.transforms import Compose, EnsureChannelFirstd, FromMetaTensord, LoadImaged, ScaleIntensityRanged, Spacingd, ToMetaTensord
+from monai.transforms import (
+    Compose,
+    EnsureChannelFirstd,
+    FromMetaTensord,
+    LoadImaged,
+    ScaleIntensityRanged,
+    Spacingd,
+    ToMetaTensord,
+)
 
 from monailabel.interfaces.tasks.infer import InferTask, InferType
 from monailabel.scribbles.transforms import (

--- a/monailabel/scribbles/infer.py
+++ b/monailabel/scribbles/infer.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.transforms import Compose, EnsureChannelFirstd, FromMetaTensord, LoadImaged, ScaleIntensityRanged, Spacingd
+from monai.transforms import Compose, EnsureChannelFirstd, FromMetaTensord, LoadImaged, ScaleIntensityRanged, Spacingd, ToMetaTensord
 
 from monailabel.interfaces.tasks.infer import InferTask, InferType
 from monailabel.scribbles.transforms import (
@@ -70,6 +70,7 @@ class ScribblesLikelihoodInferTask(InferTask):
                 scribbles_bg_label=self.scribbles_bg_label,
                 scribbles_fg_label=self.scribbles_fg_label,
             ),
+            ToMetaTensord(keys=["image", "label"]),
             Spacingd(keys=["image", "label"], pixdim=self.pix_dim, mode=["bilinear", "nearest"]),
             ScaleIntensityRanged(
                 keys="image",


### PR DESCRIPTION
it seems a `ToMetaTensord` is missing, which means the following `Spacingd` doesn't read the metadata.  this PR tries to add it back.