### PR TITLE
Allow custom python

### DIFF
--- a/monailabel/scripts/monailabel
+++ b/monailabel/scripts/monailabel
@@ -17,8 +17,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
 export PYTHONPATH=$DIR:$PYTHONPATH
 echo Using PYTHONPATH=$PYTHONPATH
 
-PYEXE=python
-version=$(python --version 2>&1)
+PYEXE=${MONILABEL_PYEXE:-python}
+version=$(${PYEXE} --version 2>&1)
 if echo "$version" | grep "Python 2"; then
   echo "Trying python3 instead of python ($version)"
   PYEXE=python3


### PR DESCRIPTION
The need for this came up in the context of installing monai label in Slicer's python environment where the interpreter executable is called `PythonSlicer`

This change allows users to set an environment variable to select the python version.