### PR TITLE
Fix for MetaTensor write issue in scribbles

### DIFF
--- a/tests/unit/scribbles/test_transforms_infer.py
+++ b/tests/unit/scribbles/test_transforms_infer.py
@@ -261,38 +261,50 @@ TEST_CASE_HISTOGRAM_GRAPHCUT = [
 ]
 
 
+def add_scribbles_from_roi(scribbles, roi, scribbles_fg_label, scribbles_bg_label):
+    mask = scribbles.astype(bool)
+    mask[
+        :,
+        roi[0] : roi[1],
+        roi[2] : roi[3],
+        roi[4] : roi[5],
+    ] = True
+    scribbles[~mask] = scribbles_bg_label
+    if not np.any(scribbles == scribbles_fg_label):
+        offset = 5
+
+        cx = int((roi[0] + roi[1]) / 2)
+        cy = int((roi[2] + roi[3]) / 2)
+        cz = int((roi[4] + roi[5]) / 2)
+
+        # add scribbles at center of roi
+        scribbles[
+            :, cx - offset : cx + offset, cy - offset : cy + offset, cz - offset : cz + offset
+        ] = scribbles_fg_label
+
+    return scribbles
+
+
 class TestScribblesTransforms(unittest.TestCase):
     @parameterized.expand(TEST_CASE_ADD_BG_ROI)
     def test_add_bg_roi_transform(self, input_param, test_input, expected_shape):
         # float32 test
         result = AddBackgroundScribblesFromROId(**input_param)(test_input)
         input_data = test_input["scribbles"].copy()
-        mask = input_data.astype(bool)
-        mask[
-            :,
-            test_input["roi"][0] : test_input["roi"][1],
-            test_input["roi"][2] : test_input["roi"][3],
-            test_input["roi"][4] : test_input["roi"][5],
-        ] = True
-        input_data[~mask] = input_param["scribbles_bg_label"]
-
+        input_data = add_scribbles_from_roi(
+            input_data, test_input["roi"], input_param["scribbles_fg_label"], input_param["scribbles_bg_label"]
+        )
         np.testing.assert_equal(input_data, result["scribbles"])
         self.assertTupleEqual(expected_shape, result["scribbles"].shape)
         self.assertTupleEqual(test_input["scribbles"].shape, result["scribbles"].shape)
 
         # int32 test
-        test_input["scribbles"] = test_input["scribbles"].astype(np.int)
+        test_input["scribbles"] = test_input["scribbles"].astype(np.int32)
         result = AddBackgroundScribblesFromROId(**input_param)(test_input)
         input_data = test_input["scribbles"].copy()
-        mask = input_data.astype(bool)
-        mask[
-            :,
-            test_input["roi"][0] : test_input["roi"][1],
-            test_input["roi"][2] : test_input["roi"][3],
-            test_input["roi"][4] : test_input["roi"][5],
-        ] = True
-        input_data[~mask] = input_param["scribbles_bg_label"]
-
+        input_data = add_scribbles_from_roi(
+            input_data, test_input["roi"], input_param["scribbles_fg_label"], input_param["scribbles_bg_label"]
+        )
         np.testing.assert_equal(input_data, result["scribbles"])
         self.assertTupleEqual(expected_shape, result["scribbles"].shape)
         self.assertTupleEqual(test_input["scribbles"].shape, result["scribbles"].shape)


### PR DESCRIPTION
Signed-off-by: masadcv <muhammad.asad@kcl.ac.uk>

- Adds a `_save_data()` to `InteractiveSegmentationTransform` to save data to `MetaTensor` when applicable to address #908 
- Fix `_fetch_data()` to address #844 
- Update scribbles unittests
- Remove deprecated `np.bool` and `np.int` in scribbles code