### PR TITLE
Cvat active learning

### DIFF
--- a/monailabel/datastore/cvat.py
+++ b/monailabel/datastore/cvat.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import logging
 import os
 import shutil
@@ -27,17 +27,42 @@ logger = logging.getLogger(__name__)
 
 
 class CVATDatastore(LocalDatastore):
-    def __init__(self, datastore_path, api_url, username=None, password=None, project="MONAILabel", **kwargs):
+    def __init__(
+        self,
+        datastore_path,
+        api_url,
+        username=None,
+        password=None,
+        project="MONAILabel",
+        task_prefix="ActiveLearning_Iteration",
+        image_quality=70,
+        labels=None,
+        normalize_label=True,
+        **kwargs,
+    ):
+        labels = labels if labels else [{"name": "Tool", "attributes": [], "color": "#66ff66"}]
+        labels = json.loads(labels) if isinstance(labels, str) else self.json()
+
         self.api_url = api_url.rstrip("/").strip()
         self.auth = HTTPBasicAuth(username, password) if username else None
         self.project = project
+        self.task_prefix = task_prefix
+        self.image_quality = image_quality
+        self.labels = labels
+        self.normalize_label = normalize_label
 
         logger.info(f"CVAT:: API URL: {api_url}")
         logger.info(f"CVAT:: UserName: {username}")
         logger.info(f"CVAT:: Password: {'*' * len(password) if password else ''}")
         logger.info(f"CVAT:: Project: {project}")
+        logger.info(f"CVAT:: Task Prefix: {task_prefix}")
+        logger.info(f"CVAT:: Image Quality: {image_quality}")
+        logger.info(f"CVAT:: Labels: {labels}")
+        logger.info(f"CVAT:: Normalize Label: {normalize_label}")
 
         super().__init__(datastore_path=datastore_path, **kwargs)
+
+        self.done_prefix = "DONE"
 
     def name(self) -> str:
         return "CVAT+Local Datastore"
@@ -45,9 +70,9 @@ class CVATDatastore(LocalDatastore):
     def description(self) -> str:
         return "CVAT+Local Datastore"
 
-    def get_cvat_project_id(self):
+    def get_cvat_project_id(self, create):
         projects = requests.get(f"{self.api_url}/api/projects", auth=self.auth).json()
-        logger.info(projects)
+        logger.debug(projects)
 
         project_id = None
         for project in projects["results"]:
@@ -55,49 +80,76 @@ class CVATDatastore(LocalDatastore):
                 project_id = project["id"]
                 break
 
-        if project_id is None:
-            body = {"name": "MONAILabel", "labels": [{"name": "Tool", "attributes": [], "color": "#66ff66"}]}
+        if create and project_id is None:
+            body = {"name": self.project, "labels": self.labels}
             project = requests.post(f"{self.api_url}/api/projects", auth=self.auth, json=body).json()
-            print(project)
+            logger.info(project)
             project_id = project["id"]
 
         logger.info(f"Using Project ID: {project_id}")
         return project_id
 
-    def get_cvat_task_id(self, project_id, task_name):
+    def get_cvat_task_id(self, project_id, create):
         tasks = requests.get(f"{self.api_url}/api/tasks", auth=self.auth).json()
-        logger.info(tasks)
+        logger.debug(tasks)
 
         task_id = None
+        task_name = ""
         for task in tasks["results"]:
-            if task["name"] == task_name:
+            if task["name"].startswith(self.task_prefix):
                 task_id = task["id"]
-                break
+                task_name = task["name"]
 
-        if task_id is None:
-            body = {"name": task_name, "labels": [], "project_id": project_id, "subset": "Train"}
+        # increment to next iteration based on latest done_xxx
+        if create:
+            if not task_name:
+                for task in tasks["results"]:
+                    if task["name"].startswith(f"{self.done_prefix}_{self.task_prefix}"):
+                        task_name = task["name"]
+
+            version = int(task_name.split("_")[-1]) + 1 if task_name else 1
+            task_name = f"{self.task_prefix}_{version}"
+            logger.info(f"Creating new CVAT Task: {task_name}; project: {self.project}")
+
+            body = {"name": task_name, "labels": [], "project_id": project_id, "subset": "Train", "segment_size": 1}
             task = requests.post(f"{self.api_url}/api/tasks", auth=self.auth, json=body).json()
-            logger.info(task)
+            logger.debug(task)
             task_id = task["id"]
 
-        logger.info(f"Using Task ID: {task_id}")
-        return project_id, task_id
+        logger.info(f"Using Task ID: {task_id}; Task Name: {task_name}")
+        return task_id, task_name
 
-    def upload_to_cvat(self, samples, task_name="ActiveLearning_Iteration_1", quality=70):
-        project_id = self.get_cvat_project_id()
-        task_id = self.get_cvat_task_id(project_id, task_name)
+    def task_status(self):
+        project_id = self.get_cvat_project_id(create=False)
+        if project_id is None:
+            return None
+        task_id, _ = self.get_cvat_task_id(project_id, create=False)
+        if task_id is None:
+            return None
 
-        file_list = [("image_quality", (None, f"{quality}"))]
+        r = requests.get(f"{self.api_url}/api/tasks/{task_id}", auth=self.auth).json()
+        return r.get("status")
+
+    def upload_to_cvat(self, samples):
+        project_id = self.get_cvat_project_id(create=True)
+        task_id, _ = self.get_cvat_task_id(project_id, create=True)
+
+        file_list = [("image_quality", (None, f"{self.image_quality}"))]
         for i, image in enumerate(samples):
-            print(f"Selected Image to upload to CVAT: {image}")
+            logger.info(f"Selected Image to upload to CVAT: {image}")
             file_list.append((f"client_files[{i}]", (os.path.basename(image), open(image, "rb"), get_mime_type(image))))
 
         r = requests.post(f"{self.api_url}/api/tasks/{task_id}/data", files=file_list, auth=self.auth).json()
         logger.info(r)
 
-    def download_from_cvat(self, task_name="ActiveLearning_Iteration_1", max_retry_count=5, wait_time=10):
-        project_id = self.get_cvat_project_id()
-        task_id = self.get_cvat_task_id(project_id, task_name)
+    def download_from_cvat(self, max_retry_count=5, retry_wait_time=10):
+        if self.task_status() != "completed":
+            logger.info("No Tasks exists with completed status to refresh/download the final labels")
+            return False
+
+        project_id = self.get_cvat_project_id(create=False)
+        task_id, task_name = self.get_cvat_task_id(project_id, create=False)
+        logger.info(f"Preparing to download/update final labels from: {project_id} => {task_id} => {task_name}")
 
         download_url = f"{self.api_url}/api/tasks/{task_id}/annotations?action=download&format=Segmentation+mask+1.1"
         tmp_folder = tempfile.TemporaryDirectory().name
@@ -108,9 +160,10 @@ class CVATDatastore(LocalDatastore):
         for retry in range(max_retry_count):
             try:
                 r = requests.get(download_url, allow_redirects=True, auth=self.auth)
-                time.sleep(wait_time)
+                time.sleep(retry_wait_time)
 
-                open(tmp_zip, "wb").write(r.content)
+                with open(tmp_zip, "wb") as fp:
+                    fp.write(r.content)
                 shutil.unpack_archive(tmp_zip, tmp_folder)
 
                 segmentations_dir = os.path.join(tmp_folder, "SegmentationClass")
@@ -121,10 +174,20 @@ class CVATDatastore(LocalDatastore):
                         os.makedirs(final_labels, exist_ok=True)
 
                         dest = os.path.join(final_labels, f)
-                        Image.open(label).convert("L").point(lambda x: 0 if x < 128 else 255, "1").save(dest)
+                        if self.normalize_label:
+                            Image.open(label).convert("L").point(lambda x: 0 if x < 128 else 255, "1").save(dest)
+                        else:
+                            Image.open(label).save(dest)
                         logger.info(f"Copy Final Label: {label} to {dest}")
-                break
+
+                # Rename after consuming/downloading the labels
+                patch_url = f"{self.api_url}/api/tasks/{task_id}"
+                body = {"name": f"{self.done_prefix}_{task_name}"}
+                r = requests.patch(patch_url, allow_redirects=True, auth=self.auth, json=body).json()
+                logger.info(r)
+                return True
             except Exception as e:
                 logger.exception(e)
                 logger.error(f"{retry} => Failed to download...")
             retry_count = retry_count + 1
+        return False

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -510,7 +510,7 @@ class MONAILabelApp:
             return {}
 
         models = list(self._trainers.keys()) if not model else [model] if isinstance(model, str) else model
-        enqueue = True if len(model) > 1 else enqueue
+        enqueue = True if len(models) > 1 else enqueue
         result = {}
         for m in models:
             if self._server_mode:
@@ -519,10 +519,10 @@ class MONAILabelApp:
                 res, _ = AsyncTask.run("train", request=request, params=params, enqueue=enqueue)
                 result[m] = res
             else:
-                url = f"/train/{model}?enqueue={enqueue}"
+                url = f"/train/{m}?enqueue={enqueue}"
                 p = params[m] if params and params.get(m) else None
                 result[m] = self._local_request(url, p, "Training")
-        return result[model] if len(model) == 1 else result
+        return result[models[0]] if len(models) == 1 else result
 
     def async_batch_infer(self, model, images: BatchInferImageType, params=None):
         if self._server_mode:

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -509,8 +509,8 @@ class MONAILabelApp:
         if not model and not self._trainers:
             return {}
 
-        models = [model] if model else list(self._trainers.keys())
-        enqueue = True if model > 1 else enqueue
+        models = list(self._trainers.keys()) if not model else [model] if isinstance(model, str) else model
+        enqueue = True if len(model) > 1 else enqueue
         result = {}
         for m in models:
             if self._server_mode:
@@ -522,7 +522,7 @@ class MONAILabelApp:
                 url = f"/train/{model}?enqueue={enqueue}"
                 p = params[m] if params and params.get(m) else None
                 result[m] = self._local_request(url, p, "Training")
-        return result[model] if model else result
+        return result[model] if len(model) == 1 else result
 
     def async_batch_infer(self, model, images: BatchInferImageType, params=None):
         if self._server_mode:

--- a/monailabel/tasks/scoring/epistemic_v2.py
+++ b/monailabel/tasks/scoring/epistemic_v2.py
@@ -34,6 +34,8 @@ class EpistemicScoring(ScoringMethod):
         infer_task: InferTask,
         num_samples=10,
         use_variance=False,
+        key_output_entropy="epistemic_entropy",
+        key_output_ts="epistemic_ts",
     ):
         super().__init__(f"Compute initial score based on dropout - {infer_task.description}")
         self.infer_task = infer_task
@@ -41,6 +43,8 @@ class EpistemicScoring(ScoringMethod):
 
         self.num_samples = num_samples
         self.use_variance = use_variance
+        self.key_output_entropy = key_output_entropy
+        self.key_output_ts = key_output_ts
 
     def entropy_volume(self, vol_input):
         # The input is assumed with repetitions, channels and then volumetric data
@@ -190,5 +194,5 @@ class EpistemicScoring(ScoringMethod):
         )
 
         # Add epistemic_entropy in datastore
-        info = {"epistemic_entropy": entropy, "epistemic_ts": model_ts}
+        info = {self.key_output_entropy: entropy, self.key_output_ts: model_ts}
         datastore.update_image_info(image_id, info)

--- a/sample-apps/endoscopy/lib/configs/deepedit.py
+++ b/sample-apps/endoscopy/lib/configs/deepedit.py
@@ -63,7 +63,7 @@ class DeepEdit(TaskConfig):
             network=self.network,
             labels=self.labels,
             roi_size=self.roi_size,
-            preload=strtobool(self.conf.get("preload", "true")),
+            preload=strtobool(self.conf.get("preload", "false")),
         )
         return task
 
@@ -88,6 +88,7 @@ class DeepEdit(TaskConfig):
                 "max_epochs": 10,
                 "train_batch_size": 8,
                 "val_batch_size": 4,
+                "val_split": 0,
             },
         )
         return task

--- a/sample-apps/endoscopy/lib/scoring/__init__.py
+++ b/sample-apps/endoscopy/lib/scoring/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cvat import CVATEpistemicScoring

--- a/sample-apps/endoscopy/lib/scoring/cvat.py
+++ b/sample-apps/endoscopy/lib/scoring/cvat.py
@@ -1,0 +1,71 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import random
+from typing import Any, Dict
+
+from monailabel.datastore.cvat import CVATDatastore
+from monailabel.interfaces.datastore import Datastore
+from monailabel.interfaces.tasks.infer import InferTask
+from monailabel.tasks.scoring.epistemic_v2 import EpistemicScoring
+
+logger = logging.getLogger(__name__)
+
+
+class CVATEpistemicScoring(EpistemicScoring):
+    def __init__(
+        self,
+        top_k,
+        infer_task: InferTask,
+        num_samples=10,
+        use_variance=False,
+    ):
+        self.top_k = top_k
+        super().__init__(infer_task, num_samples, use_variance)
+
+    def get_top_k(self, datastore: Datastore):
+        scores: Dict[str, Any] = {}
+        for image in datastore.get_unlabeled_images():
+            info = datastore.get_image_info(image)
+            scores[image] = info.get(self.key_output_entropy, 0)
+
+        scores = {k: v for k, v in sorted(scores.items(), key=lambda item: item[1], reverse=True)}  # type: ignore
+
+        # shuffle dictionary for similar scores...
+        images = list(scores.keys())
+        random.shuffle(images)
+        scores = {k: {"score": scores[k], "path": datastore.get_image_uri(k)} for k in images}
+
+        top_k: Dict[str, Any] = {}
+        max_len = self.top_k if 0 < self.top_k < len(scores) else len(scores)
+        for k, v in scores.items():
+            if len(top_k) == max_len:
+                break
+            top_k[k] = v
+        return top_k
+
+    def __call__(self, request, datastore: Datastore):
+        res = super().__call__(request, datastore)
+
+        if self.top_k and isinstance(datastore, CVATDatastore):
+            if datastore.task_status() is None and res and res.get("executed"):
+                logger.info(f"Creating new CVAT Task for top-k {self.top_k} samples")
+                top_k = self.get_top_k(datastore)
+                logger.info(f"{self.key_output_entropy}: Top-N: {list(top_k.keys())}")
+
+                if top_k:
+                    images = [top_k[image]["path"] for image in top_k]
+                    datastore.upload_to_cvat(images)
+            else:
+                logger.info("Latest Active Learning Task in CVAT is under progress/not-consumed. Skip to create new!")
+
+        return res

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -182,12 +182,13 @@ class MyApp(MONAILabelApp):
         # Check for CVAT Task if complete and trigger training
         def update_model():
             ds = self.datastore()
-            if isinstance(ds, CVATDatastore) and ds.download_from_cvat():
-                models = self.conf.get("auto_finetune_models", "tooltracking")
-                models = models.split(",")
-                logger.info(f"Trigger Training for model(s): {models}")
-
-                self.async_training(model=models)
+            if isinstance(ds, CVATDatastore):
+                name = ds.download_from_cvat()
+                if name:
+                    models = self.conf.get("auto_finetune_models", "tooltracking")
+                    models = models.split(",")
+                    logger.info(f"Trigger Training for model(s): {models}; Iteration Name: {name}")
+                    self.async_training(model=models, params={"name": name})
             else:
                 logger.info("Nothing to update;  No new labels downloaded/refreshed from CVAT")
 


### PR DESCRIPTION
Example to run the active learning lifecycle over cvat

```bash
MONAI_LABEL_DATASTORE=cvat \
MONAI_LABEL_DATASTORE_URL=http://10.117.20.110:8080 \
MONAI_LABEL_DATASTORE_USERNAME=sachi \
MONAI_LABEL_DATASTORE_PASSWORD=sachi .\
/monailabel/scripts/monailabel start_server \
  -a sample-apps/endoscopy/ \
  -s ~/Dataset/Holoscan/tiny/few/ \
  -c epistemic_enabled true \
  -c cvat_top_k 3 \
  -c auto_finetune_models tooltracking \
  -c auto_finetune_check_interval 30
```
