### PR TITLE
Remove install-time openslide dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 torch>=1.7
-monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=0.9.1
+monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, fire]>=0.9.1
 uvicorn==0.17.6
 pydantic==1.9.1
 python-dotenv==0.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ setup_requires =
     ninja
 install_requires =
     torch>=1.7
-    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=0.9.1
+    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, fire]>=0.9.1
     uvicorn==0.17.6
     pydantic==1.9.1
     python-dotenv==0.20.0


### PR DESCRIPTION
In https://github.com/Project-MONAI/MONAILabel/pull/687 openslide was made optional at runtime but it was still in the install dependencies and on some platforms (e.g. ubuntu 20.04) the regular packages don't work for building (pip install fails).  This PR allows the build to finish without openslide.

