### PR TITLE
Fix downlad_label() to load labels from Original directory

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabelLib/client.py
+++ b/plugins/slicer/MONAILabel/MONAILabelLib/client.py
@@ -170,10 +170,10 @@ class MONAILabelClient:
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
             )
 
-        if not headers.get('content-disposition'):
-            logging.warning('Filename not found. Fall back to no loaded labels')
-        file_name = re.findall('filename="(.+)"', headers.get('content-disposition'))[0]
-        
+        if not headers.get("content-disposition"):
+            logging.warning("Filename not found. Fall back to no loaded labels")
+        file_name = re.findall('filename="(.+)"', headers.get("content-disposition"))[0]
+
         file_ext = "".join(Path(file_name).suffixes)
         local_filename = tempfile.NamedTemporaryFile(dir=self._tmpdir, suffix=file_ext).name
         with open(local_filename, "wb") as f:

--- a/plugins/slicer/MONAILabel/MONAILabelLib/client.py
+++ b/plugins/slicer/MONAILabel/MONAILabelLib/client.py
@@ -47,7 +47,7 @@ class MONAILabelClient:
 
     def info(self):
         selector = "/info/"
-        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -60,7 +60,7 @@ class MONAILabelClient:
     def next_sample(self, strategy, params):
         params = self._update_client_id(params)
         selector = f"/activelearning/{MONAILabelUtils.urllib_quote_plus(strategy)}"
-        status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
+        status, response, _, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -86,7 +86,7 @@ class MONAILabelClient:
 
     def get_session(self, session_id):
         selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
-        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -98,7 +98,7 @@ class MONAILabelClient:
 
     def remove_session(self, session_id):
         selector = f"/session/{MONAILabelUtils.urllib_quote_plus(session_id)}"
-        status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -115,7 +115,7 @@ class MONAILabelClient:
         params = self._update_client_id(params)
         fields = {"params": json.dumps(params) if params else "{}"}
 
-        status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
+        status, response, _, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR,
@@ -137,7 +137,7 @@ class MONAILabelClient:
         }
         files = {"label": label_in}
 
-        status, response, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
+        status, response, _, _ = MONAILabelUtils.http_multipart("PUT", self._server_url, selector, fields, files)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR,
@@ -150,7 +150,7 @@ class MONAILabelClient:
 
     def datastore(self):
         selector = "/datastore/?output=all"
-        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -164,7 +164,7 @@ class MONAILabelClient:
         selector = "/datastore/label?label={}&tag={}".format(
             MONAILabelUtils.urllib_quote_plus(label_id), MONAILabelUtils.urllib_quote_plus(tag)
         )
-        status, response, content_disposition = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        status, response, _, content_disposition = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
@@ -191,7 +191,7 @@ class MONAILabelClient:
         files = {"label": label_in} if label_in else {}
         files.update({"file": file} if file and not session_id else {})
 
-        status, form, files = MONAILabelUtils.http_multipart("POST", self._server_url, selector, fields, files)
+        status, form, files, _ = MONAILabelUtils.http_multipart("POST", self._server_url, selector, fields, files)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR,
@@ -212,7 +212,7 @@ class MONAILabelClient:
         if model:
             selector += MONAILabelUtils.urllib_quote_plus(model)
 
-        status, response, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
+        status, response, _, _ = MONAILabelUtils.http_method("POST", self._server_url, selector, params)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR,
@@ -225,7 +225,7 @@ class MONAILabelClient:
 
     def train_stop(self):
         selector = "/train/"
-        status, response, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("DELETE", self._server_url, selector)
         if status != 200:
             raise MONAILabelException(
                 MONAILabelError.SERVER_ERROR,
@@ -240,7 +240,7 @@ class MONAILabelClient:
         selector = "/train/"
         if check_if_running:
             selector += "?check_if_running=true"
-        status, response, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
+        status, response, _, _ = MONAILabelUtils.http_method("GET", self._server_url, selector)
         if check_if_running:
             return status == 200
 
@@ -349,12 +349,12 @@ class MONAILabelUtils:
                 form, files = MONAILabelUtils.parse_multipart(response.fp if response.fp else response, response.msg)
                 logging.debug(f"Response FORM: {form}")
                 logging.debug(f"Response FILES: {files.keys()}")
-                return response.status, form, files
+                return response.status, form, files, content_disposition
             else:
-                return response.status, response.read(), content_disposition
+                return response.status, response.read(), None, content_disposition
 
         logging.debug("Reading status/content from simple response!")
-        return response.status, response.read(), content_disposition
+        return response.status, response.read(), None, content_disposition
 
     @staticmethod
     def save_result(files, tmpdir):

--- a/plugins/slicer/MONAILabel/MONAILabelLib/client.py
+++ b/plugins/slicer/MONAILabel/MONAILabelLib/client.py
@@ -170,7 +170,10 @@ class MONAILabelClient:
                 MONAILabelError.SERVER_ERROR, f"Status: {status}; Response: {response}", status, response
             )
 
-        file_name = re.findall('filename="(.+)"', headers['content-disposition'])[0]
+        if not headers.get('content-disposition'):
+            logging.warning('Filename not found. Fall back to no loaded labels')
+        file_name = re.findall('filename="(.+)"', headers.get('content-disposition'))[0]
+        
         file_ext = "".join(Path(file_name).suffixes)
         local_filename = tempfile.NamedTemporaryFile(dir=self._tmpdir, suffix=file_ext).name
         with open(local_filename, "wb") as f:


### PR DESCRIPTION
Signed-off-by: tangy5 <yucheng.tang@vanderbilt.edu>

The PR to address issue: https://github.com/Project-MONAI/MONAILabel/issues/1014

Error when load labels from original directory. "When trying to fetch the next sample from the server in slicer, original labels never appear." 

The issue is caused when calling response.getheadet(content_disposition) after response.read().

Moved the call of response.getheadet(content_disposition) in send_response and return the content_disposition , the download_label function works normal.

Let me know if the solution is good, there might be other solutions. Welcome discuss. 