### PR TITLE
Re-enable caching for get_labeled_images()

### DIFF
--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -123,6 +123,7 @@ class DICOMWebDatastore(LocalDatastore):
         logger.debug("Total Series: {}\n{}".format(len(series), "\n".join(series)))
         return series
 
+    @cached(cache=TTLCache(maxsize=16, ttl=settings.MONAI_LABEL_DICOMWEB_CACHE_EXPIRY))
     def get_labeled_images(self) -> List[str]:
         datasets = self._client.search_for_series(search_filters={"Modality": "SEG"})
         all_segs = [Dataset.from_json(ds) for ds in datasets]


### PR DESCRIPTION
In PR #949 we removed caching of the method `get_labeled_images()` of the DICOMWeb datastore. At this point, and after working a lot with the DICOMWeb datastore, I think caching this method makes perfect sense. This PR re-enables caching for `get_labeled_images()` and makes cache expiration configurable (now defaults to 180s).