### PR TITLE
Revert "Update app and proxy for GCP integration"

### DIFF
--- a/monailabel/endpoints/proxy.py
+++ b/monailabel/endpoints/proxy.py
@@ -60,8 +60,6 @@ async def proxy_dicom(op: str, path: str, response: Response):
             else settings.MONAI_LABEL_QIDO_PREFIX
             if op == "qido"
             else settings.MONAI_LABEL_STOW_PREFIX
-            if op == "stow"
-            else ""
         )
 
         # some version of ohif requests metadata using qido so change it to wado
@@ -80,11 +78,6 @@ async def proxy_dicom(op: str, path: str, response: Response):
     response.body = proxy.content
     response.status_code = proxy.status_code
     return response
-
-
-@router.get("/dicom/{path:path}", include_in_schema=False)
-async def proxy(path: str, response: Response, user: User = Depends(get_basic_user)):
-    return await proxy_dicom("", path, response)
 
 
 @router.get("/dicom/wado/{path:path}", include_in_schema=False)

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -25,7 +25,6 @@ from typing import Any, Callable, Dict, Optional, Sequence, Union
 import requests
 import schedule
 import torch
-from dicomweb_client import DICOMwebClient
 
 # added to support connecting to DICOM Store Google Cloud
 from dicomweb_client.ext.gcp.session_utils import create_session_from_gcp_credentials
@@ -150,24 +149,20 @@ class MONAILabelApp:
 
         dw_session = None
         if "googleapis.com" in self.studies:
-            # google auth case
             logger.info("Creating DICOM Credentials for Google Cloud")
             dw_session = create_session_from_gcp_credentials()
-            dw_client = DICOMwebClient(url=self.studies, session=dw_session)
-        else:
-            if settings.MONAI_LABEL_DICOMWEB_USERNAME and settings.MONAI_LABEL_DICOMWEB_PASSWORD:
-                # userID/passwd case
-                dw_session = create_session_from_user_pass(
-                    settings.MONAI_LABEL_DICOMWEB_USERNAME, settings.MONAI_LABEL_DICOMWEB_PASSWORD
-                )
-            # create dw_client using either dw_session with userID/passwd or None
-            dw_client = DICOMwebClientX(
-                url=self.studies,
-                session=dw_session,
-                qido_url_prefix=settings.MONAI_LABEL_QIDO_PREFIX,
-                wado_url_prefix=settings.MONAI_LABEL_WADO_PREFIX,
-                stow_url_prefix=settings.MONAI_LABEL_STOW_PREFIX,
+        elif settings.MONAI_LABEL_DICOMWEB_USERNAME and settings.MONAI_LABEL_DICOMWEB_PASSWORD:
+            dw_session = create_session_from_user_pass(
+                settings.MONAI_LABEL_DICOMWEB_USERNAME, settings.MONAI_LABEL_DICOMWEB_PASSWORD
             )
+
+        dw_client = DICOMwebClientX(
+            url=self.studies,
+            session=dw_session,
+            qido_url_prefix=settings.MONAI_LABEL_QIDO_PREFIX,
+            wado_url_prefix=settings.MONAI_LABEL_WADO_PREFIX,
+            stow_url_prefix=settings.MONAI_LABEL_STOW_PREFIX,
+        )
 
         self._download_dcmqi_tools()
 

--- a/tests/unit/endpoints/test_proxy.py
+++ b/tests/unit/endpoints/test_proxy.py
@@ -19,7 +19,7 @@ class MockHttpClient(MagicMock):
     def __init__(self, auth):
         pass
 
-    async def get(self, url, **kwargs):
+    async def get(self, url):
         return SimpleNamespace(content=b"xyz", status_code=400)
 
     async def __aenter__(self):


### PR DESCRIPTION
Reverts Project-MONAI/MONAILabel#1019

```python
@router.get("/dicom/{path:path}", include_in_schema=False)
async def proxy(path: str, response: Response, user: User = Depends(get_basic_user)):
    return await proxy_dicom("", path, response)```

this breaks the existing connecting/functionality with other dicom web (e.g. orthanc) over ohif