### PR TITLE
Fixes for GCP use case

### DIFF
--- a/monailabel/endpoints/proxy.py
+++ b/monailabel/endpoints/proxy.py
@@ -60,6 +60,8 @@ async def proxy_dicom(op: str, path: str, response: Response):
             else settings.MONAI_LABEL_QIDO_PREFIX
             if op == "qido"
             else settings.MONAI_LABEL_STOW_PREFIX
+            if op == "stow"
+            else ""
         )
 
         # some version of ohif requests metadata using qido so change it to wado
@@ -96,3 +98,9 @@ async def proxy_qido(path: str, response: Response, user: User = Depends(get_bas
 @router.get("/dicom/stow/{path:path}", include_in_schema=False)
 async def proxy_stow(path: str, response: Response, user: User = Depends(get_basic_user)):
     return await proxy_dicom("stow", path, response)
+
+
+# https://fastapi.tiangolo.com/tutorial/path-params/#order-matters
+@router.get("/dicom/{path:path}", include_in_schema=False)
+async def proxy(path: str, response: Response, user: User = Depends(get_basic_user)):
+    return await proxy_dicom("", path, response)

--- a/monailabel/interfaces/app.py
+++ b/monailabel/interfaces/app.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, Optional, Sequence, Union
 import requests
 import schedule
 import torch
+from dicomweb_client import DICOMwebClient
 
 # added to support connecting to DICOM Store Google Cloud
 from dicomweb_client.ext.gcp.session_utils import create_session_from_gcp_credentials
@@ -151,18 +152,19 @@ class MONAILabelApp:
         if "googleapis.com" in self.studies:
             logger.info("Creating DICOM Credentials for Google Cloud")
             dw_session = create_session_from_gcp_credentials()
-        elif settings.MONAI_LABEL_DICOMWEB_USERNAME and settings.MONAI_LABEL_DICOMWEB_PASSWORD:
-            dw_session = create_session_from_user_pass(
-                settings.MONAI_LABEL_DICOMWEB_USERNAME, settings.MONAI_LABEL_DICOMWEB_PASSWORD
+            dw_client = DICOMwebClient(url=self.studies, session=dw_session)
+        else:
+            if settings.MONAI_LABEL_DICOMWEB_USERNAME and settings.MONAI_LABEL_DICOMWEB_PASSWORD:
+                dw_session = create_session_from_user_pass(
+                    settings.MONAI_LABEL_DICOMWEB_USERNAME, settings.MONAI_LABEL_DICOMWEB_PASSWORD
+                )
+            dw_client = DICOMwebClientX(
+                url=self.studies,
+                session=dw_session,
+                qido_url_prefix=settings.MONAI_LABEL_QIDO_PREFIX,
+                wado_url_prefix=settings.MONAI_LABEL_WADO_PREFIX,
+                stow_url_prefix=settings.MONAI_LABEL_STOW_PREFIX,
             )
-
-        dw_client = DICOMwebClientX(
-            url=self.studies,
-            session=dw_session,
-            qido_url_prefix=settings.MONAI_LABEL_QIDO_PREFIX,
-            wado_url_prefix=settings.MONAI_LABEL_WADO_PREFIX,
-            stow_url_prefix=settings.MONAI_LABEL_STOW_PREFIX,
-        )
 
         self._download_dcmqi_tools()
 

--- a/tests/unit/endpoints/test_proxy.py
+++ b/tests/unit/endpoints/test_proxy.py
@@ -19,7 +19,7 @@ class MockHttpClient(MagicMock):
     def __init__(self, auth):
         pass
 
-    async def get(self, url):
+    async def get(self, url, **kwargs):
         return SimpleNamespace(content=b"xyz", status_code=400)
 
     async def __aenter__(self):


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

For GCP integration:
- Support `/dicom/` route
- Use `from dicomweb_client import DICOMwebClient`