### PR TITLE
Fix parsing of variables/settings

### DIFF
--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -325,9 +325,14 @@ class Main:
             logger.debug("                  ENV VARIABLES/SETTINGS                  ")
             logger.debug("**********************************************************")
             for k, v in settings.dict().items():
-                v = json.dumps(v) if isinstance(v, list) or isinstance(v, dict) else (str(v) if v else None)
+                if isinstance(v, list) or isinstance(v, dict):
+                    v = json.dumps(v)
+                elif v is not None:
+                    v = str(v)
+                else:
+                    v = None
                 logger.debug(f"{'set' if any(platform.win32_ver()) else 'export'} {k}={v}")
-                if v:
+                if v is not None:
                     os.environ[k] = v
             logger.debug("**********************************************************")
             logger.debug("")

--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -325,9 +325,10 @@ class Main:
             logger.debug("                  ENV VARIABLES/SETTINGS                  ")
             logger.debug("**********************************************************")
             for k, v in settings.dict().items():
-                v = json.dumps(v) if isinstance(v, list) or isinstance(v, dict) else str(v)
+                v = json.dumps(v) if isinstance(v, list) or isinstance(v, dict) else (str(v) if v else None)
                 logger.debug(f"{'set' if any(platform.win32_ver()) else 'export'} {k}={v}")
-                os.environ[k] = v
+                if v:
+                    os.environ[k] = v
             logger.debug("**********************************************************")
             logger.debug("")
 


### PR DESCRIPTION
In #1048 some setting variables were defined to default to `NoneType`.

During `start_server()` these variables are parsed and re-set from `NoneType` to `str` 
 because of `str(None) = "None"`. This leads to malforming of the resulting Qido-, Wado- and Stow-Prefixes and wrong URLs.

This PR fixes the parsing of `NoneType` settings.

Co-authored by @markus-hinsche 