### PR TITLE
Fix Post Transform for multi label output of segmentation_nuclei

### DIFF
--- a/monailabel/transform/post.py
+++ b/monailabel/transform/post.py
@@ -189,8 +189,7 @@ class FindContoursd(MapTransform):
             logger.debug(f"Total Unique Masks (excluding background): {labels}")
             for label_idx in labels:
                 p = d[key].array if isinstance(d[key], MetaTensor) else d[key]
-                p = p.astype(np.uint8)
-                p[p == label_idx] = 1
+                p = np.where(p == label_idx, 1, 0).astype(np.uint8)
 
                 label_name = self.labels.get(label_idx, label_idx)
                 label_names.add(label_name)

--- a/sample-apps/pathology/lib/infers/segmentation_nuclei.py
+++ b/sample-apps/pathology/lib/infers/segmentation_nuclei.py
@@ -75,8 +75,8 @@ class SegmentationNuclei(BasicInferTask):
     def post_transforms(self, data=None) -> Sequence[Callable]:
         return [
             EnsureTyped(keys="pred", device=data.get("device") if data else None),
-            Activationsd(keys="pred", softmax=len(self.labels) > 1, sigmoid=len(self.labels) == 1),
-            AsDiscreted(keys="pred", argmax=len(self.labels) > 1, threshold=0.5 if len(self.labels) == 1 else None),
+            Activationsd(keys="pred", softmax=True),
+            AsDiscreted(keys="pred", argmax=True),
             SqueezeDimd(keys="pred", dim=0),
             ToNumpyd(keys=("image", "pred")),
             PostFilterLabeld(keys="pred", image="image"),

--- a/sample-apps/pathology/lib/transforms.py
+++ b/sample-apps/pathology/lib/transforms.py
@@ -199,7 +199,7 @@ class PostFilterLabeld(MapTransform):
             if self.min_hole:
                 label = remove_small_holes(label, area_threshold=self.min_hole)
 
-            d[key] = label.astype(np.uint8)
+            d[key] = np.where(label > 0, d[key], 0)
         return d
 
 


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

All the cells are output as "Neoplastic Cells" due to post transform error (while removing small objects) and finding contours

After fix:
![image](https://user-images.githubusercontent.com/7339051/195734842-a5d4e568-e569-4526-83b5-67c800d5c6fd.png)

