### PR TITLE
Upgrade monai to 1.0.1 rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # please run `./runtests.sh --clean && DOCKER_BUILDKIT=1 docker build -t projectmonai/monailabel:latest .`
 # to use different version of MONAI pass `--build-arg MONAI_IMAGE=...`
 
-ARG MONAI_IMAGE=projectmonai/monai:1.0.0
+ARG MONAI_IMAGE=projectmonai/monai:1.0.1rc1
 ARG BUILD_OHIF=true
 
 FROM ${MONAI_IMAGE} as build

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 torch>=1.7
-monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.0
+monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc1
 uvicorn==0.17.6
 pydantic==1.9.1
 python-dotenv==0.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ setup_requires =
     ninja
 install_requires =
     torch>=1.7
-    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.0
+    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc1
     uvicorn==0.17.6
     pydantic==1.9.1
     python-dotenv==0.20.0


### PR DESCRIPTION
Unit Test and Integration passed locally with GPU. 
Upgrade to 1.0.1rc1

Unit and Integration tests passed locally by running
` ./runtests.sh --net ./runtests.sh -u`

0.5.2 activities tracking: https://github.com/Project-MONAI/MONAILabel/issues/1067