### PR TITLE
Add endoscopy integration test infer and trainer

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -470,4 +470,5 @@ if [ $doNetTests = true ]; then
   run_integration_tests "radiology" "tests/data/dataset/local/spleen" "deepedit,segmentation_spleen,segmentation,deepgrow_2d,deepgrow_3d"
   run_integration_tests "pathology" "tests/data/pathology" "deepedit_nuclei,segmentation_nuclei,nuclick"
   run_integration_tests "monaibundle" "tests/data/dataset/local/spleen" "spleen_ct_segmentation_v0.1.0,spleen_deepedit_annotation_v0.1.0,swin_unetr_btcv_segmentation_v0.1.0"
+  run_integration_tests "endoscopy" "tests/data/endoscopy" "tooltracking,inbody,deepedit"
 fi

--- a/tests/integration/endoscopy/__init__.py
+++ b/tests/integration/endoscopy/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/endoscopy/test_infer.py
+++ b/tests/integration/endoscopy/test_infer.py
@@ -12,6 +12,7 @@ import unittest
 
 import requests
 import torch
+
 from tests.integration import SERVER_URI
 
 

--- a/tests/integration/endoscopy/test_infer.py
+++ b/tests/integration/endoscopy/test_infer.py
@@ -1,0 +1,51 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import requests
+import torch
+from tests.integration import SERVER_URI
+
+
+class EndPointInfer(unittest.TestCase):
+    def test_tooltracking(self):
+        if not torch.cuda.is_available():
+            return
+
+        model = "tooltracking"
+        image = "Video_2_VTS_01_1_Trim_04-40_f600"
+
+        response = requests.post(f"{SERVER_URI}/infer/{model}?image={image}")
+        assert response.status_code == 200
+
+    def test_inbody(self):
+        if not torch.cuda.is_available():
+            return
+
+        model = "inbody"
+        image = "Video_2_VTS_01_1_Trim_04-40_f600"
+
+        response = requests.post(f"{SERVER_URI}/infer/{model}?image={image}&output=json")
+        assert response.status_code == 200
+
+    def test_deepedit(self):
+        if not torch.cuda.is_available():
+            return
+
+        model = "deepedit"
+        image = "Video_2_VTS_01_1_Trim_04-40_f600"
+
+        response = requests.post(f"{SERVER_URI}/infer/{model}?image={image}")
+        assert response.status_code == 200
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/endoscopy/test_trainer.py
+++ b/tests/integration/endoscopy/test_trainer.py
@@ -12,6 +12,7 @@ import unittest
 
 import requests
 import torch
+
 from tests.integration import SERVER_URI
 
 

--- a/tests/integration/endoscopy/test_trainer.py
+++ b/tests/integration/endoscopy/test_trainer.py
@@ -1,0 +1,50 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import requests
+import torch
+from tests.integration import SERVER_URI
+
+
+class EndPointSession(unittest.TestCase):
+    def test_tooltracking_trainer(self):
+        if not torch.cuda.is_available():
+            return
+
+        params = {
+            "model": "tooltracking",
+            "max_epochs": 1,
+            "name": "net_test_tooltracking_trainer_01",
+            "val_split": 0.5,
+            "multi_gpu": False,
+        }
+
+        response = requests.post(f"{SERVER_URI}/train/tooltracking?run_sync=True", json=params)
+        assert response.status_code == 200
+
+    def test_deepedit_trainer(self):
+        if not torch.cuda.is_available():
+            return
+
+        params = {
+            "model": "deepedit",
+            "max_epochs": 1,
+            "name": "net_test_deepedit_trainer_01",
+            "val_split": 0.5,
+            "multi_gpu": False,
+        }
+        response = requests.post(f"{SERVER_URI}/train/deepedit?run_sync=True", json=params)
+        assert response.status_code == 200
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -42,5 +42,6 @@ def run_main():
         os.makedirs(os.path.join(TEST_DATA, "endoscopy"))
         extractall(filepath=downloaded_endoscopy_file, output_dir=os.path.join(TEST_DATA, "endoscopy"))
 
+
 if __name__ == "__main__":
     run_main()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -34,6 +34,13 @@ def run_main():
         os.makedirs(os.path.join(TEST_DATA, "pathology"))
         shutil.copy(downloaded_pathology_file, os.path.join(TEST_DATA, "pathology"))
 
+    downloaded_endoscopy_file = os.path.join(TEST_DIR, "downloads", "endoscopy_frames.zip")
+    endoscopy_url = "https://drive.google.com/uc?export=download&id=115fS_RZxOXMFb3wgepS2aJA2XYpXjHOU"
+    if not os.path.exists(downloaded_endoscopy_file):
+        download_url(url=endoscopy_url, filepath=downloaded_endoscopy_file)
+    if not os.path.exists(os.path.join(TEST_DATA, "endoscopy")):
+        os.makedirs(os.path.join(TEST_DATA, "endoscopy"))
+        extractall(filepath=downloaded_endoscopy_file, output_dir=os.path.join(TEST_DATA, "endoscopy"))
 
 if __name__ == "__main__":
     run_main()


### PR DESCRIPTION
The PR adds integration endoscopy test for inference and trainer. As part of 0.5.2 release.

Endoscopy test sample frames are created, test will automatically download test frames to tests/data/endoscopy
Verified locally with GPU run. 

