### PR TITLE
Support update nuclio cvat model from bundle

### DIFF
--- a/sample-apps/endoscopy/README.md
+++ b/sample-apps/endoscopy/README.md
@@ -124,14 +124,17 @@ monailabel start_server \
   --conf auto_finetune_check_interval 30
 ```
 
-#### Update/Publish latest model back to CVAT
+#### Fetch and Publish latest model to CVAT/Nuclio
 After re-train the fine-tuned model meets all the conditions to be considered as a good model.  You can push the model to cvat/nuclio function container.
 ```bash
-workspace/endoscopy/update_cvat_model.sh <FUNCTION_NAME> <MODEL_PATH>
+workspace/endoscopy/update_cvat_model.sh <FUNCTION_NAME> 
 
-# publish tool tracking model (run this command on the node where cvat/nuclio containers are running)
-workspace/endoscopy/update_cvat_model.sh tootracking ./workspace/endoscopy/model/tooltracking.pt
-
+# Bundle Example: publish tool tracking bundle trained model (run this command on the node where cvat/nuclio containers are running)
+workspace/endoscopy/update_cvat_model.sh tootracking 
+# Bundle Example: publish inbody trained model 
+workspace/endoscopy/update_cvat_model.sh inbody 
+# DeepEdit Example: publish deepedit trained model (Not from bundle)
+workspace/endoscopy/update_cvat_model.sh deepedit 
 ```
 
 Following are additional configs *(pass them as **--conf name value**) are useful when you use CVAT for Active Learning workflow.

--- a/sample-apps/endoscopy/README.md
+++ b/sample-apps/endoscopy/README.md
@@ -127,14 +127,14 @@ monailabel start_server \
 #### Fetch and Publish latest model to CVAT/Nuclio
 After re-train the fine-tuned model meets all the conditions to be considered as a good model.  You can push the model to cvat/nuclio function container.
 ```bash
-workspace/endoscopy/update_cvat_model.sh <FUNCTION_NAME> 
+workspace/endoscopy/update_cvat_model.sh <FUNCTION_NAME>
 
 # Bundle Example: publish tool tracking bundle trained model (run this command on the node where cvat/nuclio containers are running)
-workspace/endoscopy/update_cvat_model.sh tootracking 
-# Bundle Example: publish inbody trained model 
-workspace/endoscopy/update_cvat_model.sh inbody 
+workspace/endoscopy/update_cvat_model.sh tootracking
+# Bundle Example: publish inbody trained model
+workspace/endoscopy/update_cvat_model.sh inbody
 # DeepEdit Example: publish deepedit trained model (Not from bundle)
-workspace/endoscopy/update_cvat_model.sh deepedit 
+workspace/endoscopy/update_cvat_model.sh deepedit
 ```
 
 Following are additional configs *(pass them as **--conf name value**) are useful when you use CVAT for Active Learning workflow.

--- a/sample-apps/endoscopy/update_cvat_model.sh
+++ b/sample-apps/endoscopy/update_cvat_model.sh
@@ -34,7 +34,7 @@ if [ ! $(docker inspect -f '{{.State.Status}}' $FUNC_CONTAINER) == "running" ]; 
     echo "$FUNC_CONTAINER container is not running, can not publish to container..."
 fi
 
-# Fetch latest model 
+# Fetch latest model
 if [ $FUNC_NAME == "deepedit" ];then
     MODEL_PATH="$APP_ROOT/model/$FUNC_NAME.pt"
     # Replace prior pretrained model with lastest model as current pre-trained model


### PR DESCRIPTION
 Update the publishing model cvat, support the latest endoscopy from bundle. 
Users do not need to specify model path, it will fetch the model given the function name

`workspace/endoscopy/update_cvat_model.sh tootracking 
`

If the model is from bundle, such as tooltracking, inbody, publish model to the bundle model in Nuclio function container.
If the model is not from bundle, such as deepedit, publish as before. 