### PR TITLE
Updates: Upgrade MONAI rc3 | Pydantic 1.8.2 | bundle path add | Orthanc Doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # please run `./runtests.sh --clean && DOCKER_BUILDKIT=1 docker build -t projectmonai/monailabel:latest .`
 # to use different version of MONAI pass `--build-arg MONAI_IMAGE=...`
 
-ARG MONAI_IMAGE=projectmonai/monai:1.0.1rc2
+ARG MONAI_IMAGE=projectmonai/monai:1.0.1rc3
 ARG BUILD_OHIF=true
 
 FROM ${MONAI_IMAGE} as build

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -277,7 +277,7 @@ endpoint of our DICOM server, which based on the last section is ``http://locaho
   # and start annotating images in our DICOM server
   monailabel start_server --app radiology --studies http://locahost:8042/dicom-web --conf models deepedit --username orthanc --password orthanc
 
-  # For MONAI label version >=0.3.0, if you have authentication set for dicom-web then you can pass the credentials using environment 
+  # For MONAI label version >=0.3.0, if you have authentication set for dicom-web then you can pass the credentials using environment
   #`variables <https://github.com/Project-MONAI/MONAILabel/blob/main/monailabel/config.py>`_ while running the server.
   export MONAI_LABEL_DICOMWEB_USERNAME=xyz
   export MONAI_LABEL_DICOMWEB_PASSWORD=abc

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -273,10 +273,15 @@ endpoint of our DICOM server, which based on the last section is ``http://locaho
   # download DeepEdit sample app to local directory
   monailabel apps --name radiology --download --output .
 
-  # start the DeepEdit app in MONAI label server
+  # For MONAI Label version <=0.2.0, pass credentials and start the DeepEdit app in MONAI label server
   # and start annotating images in our DICOM server
   monailabel start_server --app radiology --studies http://locahost:8042/dicom-web --conf models deepedit --username orthanc --password orthanc
 
+  # For MONAI label version >=0.3.0, if you have authentication set for dicom-web then you can pass the credentials using environment 
+  #`variables <https://github.com/Project-MONAI/MONAILabel/blob/main/monailabel/config.py>`_ while running the server.
+  export MONAI_LABEL_DICOMWEB_USERNAME=xyz
+  export MONAI_LABEL_DICOMWEB_PASSWORD=abc
+  monailabel start_server --app apps/radiology --studies http://127.0.0.1:8042/dicom-web --conf models deepedit
 
 At this point OHIF can be used to annotate the data in the DICOM server via the MONAI Label server ``/ohif`` endpoint
 (e.g. via `http://127.0.0.1:8000/ohif <http://127.0.0.1:8000/ohif>`_).
@@ -424,11 +429,8 @@ Prerequisite: Check Model Zoo `Release <https://github.com/Project-MONAI/model-z
   # Step 3: download a local study images, sample dataset such as spleen CT (contrast enhanced CTs are better):
   monailabel datasets --download --name Task09_Spleen --output .
 
-  # Step4: set customised bundle scripts to python path (the bundle models and code are downloaded when start monai label server)
-  export PYTHONPATH=$PYTHONPATH:"monaibundle/model/renalStructures_UNEST_segmentation_v0.2.0"
-
-  # Step 5: start the bundle app in MONAI label server
-    monailabel start_server --app monaibundle --studies Task09_Spleen/imagesTr --conf models renalStructures_UNEST_segmentation_v0.2.0
+  # Step 4: start the bundle app in MONAI label server
+  monailabel start_server --app monaibundle --studies Task09_Spleen/imagesTr --conf models renalStructures_UNEST_segmentation_v0.2.0
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@
 # limitations under the License.
 
 torch>=1.7
-monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc2
+monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc3
 uvicorn==0.17.6
-pydantic==1.9.1
+pydantic>=1.8.2
 python-dotenv==0.20.0
 fastapi==0.78.0
 python-multipart==0.0.5

--- a/sample-apps/monaibundle/main.py
+++ b/sample-apps/monaibundle/main.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import re
+import sys
 import shutil
 from typing import Dict
 
@@ -80,6 +81,7 @@ class MyApp(MONAILabelApp):
                     e = os.path.join(self.model_dir, re.sub(r"_v.*.zip", "", f"{k}.zip"))
                     if os.path.isdir(e):
                         shutil.move(e, p)
+            sys.path.append(p)
 
             self.models[k] = p
 

--- a/sample-apps/monaibundle/main.py
+++ b/sample-apps/monaibundle/main.py
@@ -12,8 +12,8 @@
 import logging
 import os
 import re
-import sys
 import shutil
+import sys
 from typing import Dict
 
 import requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,9 @@ setup_requires =
     ninja
 install_requires =
     torch>=1.7
-    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc2
+    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire]>=1.0.1rc3
     uvicorn==0.17.6
-    pydantic==1.9.1
+    pydantic>=1.8.2
     python-dotenv==0.20.0
     fastapi==0.78.0
     python-multipart==0.0.5


### PR DESCRIPTION
Some updates for monai 0.5.2 release:

1. Upgrade dependencies of MONAI 1.0.1rc3
2. Use Pydantic>=1.8.2 for consistency with Toolkit version. (1.8.0 and 1.8.1 have conflict with fastapi package)
3. monaibundle app: add support to automatically append sys env path so that users won't need to add path themselves. Minimized installation steps for monaibundle app with bundle models that contains customized scripts. Such as renal and pancreas bundles. Single command works and verified for those special bundles. E.g.,: 

` monailabel start_server --app . --studies Task09_Spleen/imagesTr --conf models renalStructures_UNEST_segmentation_v0.2.0`

4. Fix a small thing in the Documentation Quickstart about Orthanc credentials command, some users mentioned the doc is confusing as 
`monailabel start_server --app radiology --studies http://locahost:8042/dicom-web --conf models deepedit --username orthanc --password orthanc`
doesn't work for monailabel>=0.3.0

5. Passed all unit and integration tests with local GPU run. 
