### PR TITLE
Flag to disable tracking for training task

### DIFF
--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -464,10 +464,10 @@ class BasicTrainTask(TrainTask):
         if self._disable_tracking:
             set_track_meta(False)
 
-        context.trainer.run()
-
-        # In case of same process (restore)
-        set_track_meta(meta_tracking)
+        try:
+            context.trainer.run()
+        finally:
+            set_track_meta(meta_tracking)  # In case of same process (restore)
 
         if context.multi_gpu:
             torch.distributed.destroy_process_group()

--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -32,7 +32,9 @@ from monai.data import (
     PersistentDataset,
     SmartCacheDataset,
     ThreadDataLoader,
+    get_track_meta,
     partition_dataset,
+    set_track_meta,
 )
 from monai.engines import SupervisedEvaluator, SupervisedTrainer
 from monai.handlers import (
@@ -167,6 +169,7 @@ class BasicTrainTask(TrainTask):
         self._find_unused_parameters = find_unused_parameters
         self._load_strict = load_strict
         self._labels = [] if labels is None else [labels] if isinstance(labels, str) else labels
+        self._disable_tracking = kwargs.get("disable_tracking", True)
 
     @abstractmethod
     def network(self, context: Context):
@@ -455,7 +458,16 @@ class BasicTrainTask(TrainTask):
 
         # Finalize and Run Training
         self.finalize(context)
+
+        # Disable Tracking
+        meta_tracking = get_track_meta()
+        if self._disable_tracking:
+            set_track_meta(False)
+
         context.trainer.run()
+
+        # In case of same process (restore)
+        set_track_meta(meta_tracking)
 
         if context.multi_gpu:
             torch.distributed.destroy_process_group()


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>
This is to run some transforms faster while training... Most of the case, we don't need invert transform while training a model.
However use can enable it if required.