### PR TITLE
Fix building of OHIF in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 # to use different version of MONAI pass `--build-arg MONAI_IMAGE=...`
 
 ARG MONAI_IMAGE=projectmonai/monai:1.0.1
-ARG BUILD_OHIF=true
 
 FROM ${MONAI_IMAGE} as build
 LABEL maintainer="monai.contact@gmail.com"
+ARG BUILD_OHIF=true
 
 ADD . /opt/monailabel/
 RUN apt update -y && apt install openslide-tools npm -y && npm install --global yarn


### PR DESCRIPTION
OHIF never gets built in Docker image due to a misplaced build argument. This PR re-activates the default building of OHIF in MONAILabel's Docker image.

See also https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact and https://stackoverflow.com/a/56748289