### PR TITLE
Add endoscopic bundle name option

### DIFF
--- a/sample-apps/endoscopy/lib/configs/inbody.py
+++ b/sample-apps/endoscopy/lib/configs/inbody.py
@@ -34,7 +34,7 @@ class InBody(TaskConfig):
         super().init(name, model_dir, conf, planner, **kwargs)
 
         bundle_name = conf.get("bundle_name", "endoscopic_inbody_classification")
-        bundle_version = "0.2.0"
+        bundle_version = conf.get("bundle_version", "0.2.0")
         self.bundle_path = os.path.join(self.model_dir, bundle_name)
         if not os.path.exists(self.bundle_path):
             download(name=bundle_name, version=bundle_version, bundle_dir=self.model_dir)

--- a/sample-apps/endoscopy/lib/configs/inbody.py
+++ b/sample-apps/endoscopy/lib/configs/inbody.py
@@ -34,8 +34,6 @@ class InBody(TaskConfig):
         super().init(name, model_dir, conf, planner, **kwargs)
 
         bundle_name = conf.get("bundle_name", "endoscopic_inbody_classification")
-
-        bundle_name = "endoscopic_inbody_classification"
         bundle_version = "0.2.0"
         self.bundle_path = os.path.join(self.model_dir, bundle_name)
         if not os.path.exists(self.bundle_path):

--- a/sample-apps/endoscopy/lib/configs/inbody.py
+++ b/sample-apps/endoscopy/lib/configs/inbody.py
@@ -33,6 +33,8 @@ class InBody(TaskConfig):
     def init(self, name: str, model_dir: str, conf: Dict[str, str], planner: Any, **kwargs):
         super().init(name, model_dir, conf, planner, **kwargs)
 
+        bundle_name = conf.get("bundle_name", "endoscopic_inbody_classification")
+
         bundle_name = "endoscopic_inbody_classification"
         bundle_version = "0.2.0"
         self.bundle_path = os.path.join(self.model_dir, bundle_name)

--- a/sample-apps/endoscopy/lib/configs/tooltracking.py
+++ b/sample-apps/endoscopy/lib/configs/tooltracking.py
@@ -32,9 +32,9 @@ logger = logging.getLogger(__name__)
 class ToolTracking(TaskConfig):
     def init(self, name: str, model_dir: str, conf: Dict[str, str], planner: Any, **kwargs):
         super().init(name, model_dir, conf, planner, **kwargs)
-        
+
         bundle_name = conf.get("bundle_name", "endoscopic_tool_segmentation")
-        bundle_version = "0.2.0"
+        bundle_version = conf.get("bundle_version", "0.2.0")
         self.bundle_path = os.path.join(self.model_dir, bundle_name)
         if not os.path.exists(self.bundle_path):
             download(name=bundle_name, version=bundle_version, bundle_dir=self.model_dir)

--- a/sample-apps/endoscopy/lib/configs/tooltracking.py
+++ b/sample-apps/endoscopy/lib/configs/tooltracking.py
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 class ToolTracking(TaskConfig):
     def init(self, name: str, model_dir: str, conf: Dict[str, str], planner: Any, **kwargs):
         super().init(name, model_dir, conf, planner, **kwargs)
-
-        bundle_name = "endoscopic_tool_segmentation"
+        
+        bundle_name = conf.get("bundle_name", "endoscopic_tool_segmentation")
         bundle_version = "0.2.0"
         self.bundle_path = os.path.join(self.model_dir, bundle_name)
         if not os.path.exists(self.bundle_path):


### PR DESCRIPTION
Small change for endoscopic models config: tooltracking and inbody.
Add conf options so that users can load/initiate tooltracking/inbody models with any name in local workspace. 
This is partly for MONAI Toolkit loading bundle from NGC, they can have other names if not download from Github.