### PR TITLE
Enable CVAT-Nuclio Windows connection for endoscopy app

### DIFF
--- a/plugins/cvat/endoscopy/deepedit.yaml
+++ b/plugins/cvat/endoscopy/deepedit.yaml
@@ -53,6 +53,7 @@ spec:
       workerAvailabilityTimeoutMilliseconds: 10000
       attributes:
         maxRequestBodySize: 33554432 # 32MB
+        port: 8902
 
   resources:
     limits:
@@ -64,3 +65,4 @@ spec:
         name: always
         maximumRetryCount: 1
       mountMode: volume
+      network: cvat_cvat

--- a/plugins/cvat/endoscopy/inbody.yaml
+++ b/plugins/cvat/endoscopy/inbody.yaml
@@ -50,6 +50,7 @@ spec:
       workerAvailabilityTimeoutMilliseconds: 10000
       attributes:
         maxRequestBodySize: 33554432 # 32MB
+        port: 8901
 
   resources:
     limits:
@@ -61,3 +62,4 @@ spec:
         name: always
         maximumRetryCount: 1
       mountMode: volume
+      network: cvat_cvat

--- a/plugins/cvat/endoscopy/tooltracking.yaml
+++ b/plugins/cvat/endoscopy/tooltracking.yaml
@@ -49,6 +49,7 @@ spec:
       workerAvailabilityTimeoutMilliseconds: 10000
       attributes:
         maxRequestBodySize: 33554432 # 32MB
+        port: 8900
 
   resources:
     limits:
@@ -60,3 +61,4 @@ spec:
         name: always
         maximumRetryCount: 1
       mountMode: volume
+      network: cvat_cvat


### PR DESCRIPTION
Modify YML file to support Window usage as discussed with Marc.

Unblock the connect between Nuclio and CVAT on Windows. 