### PR TITLE
Set default val_split to 0.2 for bundle trainer

### DIFF
--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -112,7 +112,7 @@ class BundleTrainTask(TrainTask):
         datalist = [{"image": d["image"], "label": d["label"]} for d in datalist if d]
         logger.info(f"Total Records in Dataset: {len(datalist)}")
 
-        val_split = request.get("val_split", 0.0)
+        val_split = request.get("val_split", 0.2)
         if val_split > 0.0:
             train_datalist, val_datalist = partition_dataset(
                 datalist, ratios=[(1 - val_split), val_split], shuffle=shuffle

--- a/sample-apps/endoscopy/README.md
+++ b/sample-apps/endoscopy/README.md
@@ -118,6 +118,7 @@ export MONAI_LABEL_DATASTORE_PASSWORD=mypass
 monailabel start_server \
   --app workspace/endoscopy \
   --studies workspace/images \
+  --conf models tooltracking \
   --conf epistemic_enabled true \
   --conf epistemic_top_k 10 \
   --conf auto_finetune_models tooltracking \

--- a/sample-apps/endoscopy/README.md
+++ b/sample-apps/endoscopy/README.md
@@ -119,10 +119,14 @@ monailabel start_server \
   --app workspace/endoscopy \
   --studies workspace/images \
   --conf epistemic_enabled true \
-  --conf epistemic_top_k 3 \
+  --conf epistemic_top_k 10 \
   --conf auto_finetune_models tooltracking \
   --conf auto_finetune_check_interval 30
 ```
+
+Note: the argument ```epistemic_top_k``` specifies the number of images to label in each iteration, provide a number above 5 if there is no externally provided validation data
+MONAI Label server will automatically split annotated data into train and validation by percentage. No external validation data and ```epistemic_top_k``` < 5 will lead to traning with no
+saved model.
 
 #### Fetch and Publish latest model to CVAT/Nuclio
 After re-train the fine-tuned model meets all the conditions to be considered as a good model.  You can push the model to cvat/nuclio function container.


### PR DESCRIPTION
To avoid confusion to new users with monai bundle and endoscopy app in MONAI Label. Set val_split to 0.2

In endoscopy, suggest users to set ``epistemic_top_k``` to a number above 5 if no external validation set provided, to guarantee at least 1 validation data will be created.  