### PR TITLE
Add a setting that slightly speeds up invoking the dsa plugin.

### DIFF
--- a/plugins/dsa/cli/slicer_cli_list.json
+++ b/plugins/dsa/cli/slicer_cli_list.json
@@ -1,6 +1,9 @@
 {
   "MONAILabelAnnotation": {
-    "type"    : "python"
+    "type": "python",
+    "docker-params": {
+        "network_mode": "host"
+    }
   },
   "MONAILabelTraining": {
     "type"    : "python"


### PR DESCRIPTION
This saves around 0.75 seconds per run as it avoids Docker performing some network isolation.

There still seems to be some overhead that is larger than I expect at the tail end of the receiving the data back from the MONAI Label server.  Hopefully I'll have another PR that addresses that.