### PR TITLE
Fix lab_ext parameter not used

### DIFF
--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -209,7 +209,7 @@ def create_dataset_from_path(folder, image_dir="images", label_dir="labels", img
     images = _list_files(image_dir, img_ext)
 
     label_dir = os.path.join(folder, label_dir) if label_dir else folder
-    labels = _list_files(label_dir, img_ext)
+    labels = _list_files(label_dir, lab_ext)
 
     for i, l in zip(images, labels):
         if get_basename_no_ext(i) != get_basename_no_ext(l):


### PR DESCRIPTION
Tiny PR by me to get my foot in the door :smile: 

Looks like lab_ext parameter was not used in create_dataset_from_path, I've put in the `labels`  _list_files search

Signed-off-by: Anders Sildnes <andsild@posteo.net>