### PR TITLE
Add Detection Task Support - Infer

### DIFF
--- a/monailabel/interfaces/tasks/infer_v2.py
+++ b/monailabel/interfaces/tasks/infer_v2.py
@@ -28,6 +28,7 @@ class InferType(str, Enum):
         DEEPGROW -                Deepgrow Interactive Model
         DEEPEDIT -                DeepEdit Interactive Model
         SCRIBBLES -               Scribbles Model
+        DETECTION -               Detection Model
         OTHERS -                  Other Model Type
     """
 
@@ -37,6 +38,7 @@ class InferType(str, Enum):
     DEEPGROW: str = "deepgrow"
     DEEPEDIT: str = "deepedit"
     SCRIBBLES: str = "scribbles"
+    DETECTION: str = "detection"
     OTHERS: str = "others"
 
 

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -558,9 +558,10 @@ class BasicInferTask(InferTask):
             return cw(data)
 
         if self.type == InferType.DETECTION:
-            writer = DetectionWriter(pred_box_key=self.target_box_key, pred_label_key=self.target_label_key)
-        else:
-            writer = Writer(label=self.output_label_key, json=self.output_json_key)        
+            dw = DetectionWriter(pred_box_key=self.target_box_key, pred_label_key=self.target_label_key)
+            return dw(data)
+        
+        writer = Writer(label=self.output_label_key, json=self.output_json_key)        
             
         return writer(data)
 

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -14,10 +14,10 @@ import logging
 import os
 from typing import Callable, Dict, Optional, Sequence, Union
 
+from monai.apps.detection.networks.retinanet_detector import RetinaNetDetector
 from monai.bundle import ConfigParser
 from monai.inferers import Inferer, SimpleInferer
 from monai.transforms import Compose, LoadImaged, SaveImaged
-from monai.apps.detection.networks.retinanet_detector import RetinaNetDetector
 
 from monailabel.interfaces.tasks.infer_v2 import InferType
 from monailabel.tasks.infer.basic_infer import BasicInferTask
@@ -64,6 +64,7 @@ class BundleConstants:
 
     def key_detector_ops(self) -> Sequence[str]:
         return ["detector_ops"]
+
 
 class BundleInferTask(BasicInferTask):
     """
@@ -126,7 +127,9 @@ class BundleInferTask(BasicInferTask):
         spatial_shape = image.get("spatial_shape")
         dimension = len(spatial_shape) if spatial_shape else 3
         type = self._get_type(description, type)
-        self.add_post_restore = False if type == "detection" else add_post_restore # if detection task, set post restore to False by default.
+        self.add_post_restore = (
+            False if type == "detection" else add_post_restore
+        )  # if detection task, set post restore to False by default.
 
         super().__init__(
             path=model_path,
@@ -190,15 +193,13 @@ class BundleInferTask(BasicInferTask):
 
     def _get_type(self, description, type):
         return (
-            (
-                InferType.DEEPEDIT
-                if "deepedit" in description.lower()
-                else InferType.DEEPGROW
-                if "deepgrow" in description.lower()
-                else InferType.DETECTION
-                if "detection" in description.lower()
-                else InferType.SEGMENTATION
-            )
+            InferType.DEEPEDIT
+            if "deepedit" in description.lower()
+            else InferType.DEEPGROW
+            if "deepgrow" in description.lower()
+            else InferType.DETECTION
+            if "detection" in description.lower()
+            else InferType.SEGMENTATION
         )
 
     def _filter_transforms(self, transforms, filters):

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -75,7 +75,7 @@ class BundleInferTask(BasicInferTask):
         path: str,
         conf: Dict[str, str],
         const: Optional[BundleConstants] = None,
-        type: Union[str, InferType] = None,
+        type: Union[str, InferType] = InferType.SEGMENTATION,
         pre_filter: Optional[Sequence] = None,
         post_filter: Optional[Sequence] = [SaveImaged],
         extend_load_image: bool = True,
@@ -199,8 +199,6 @@ class BundleInferTask(BasicInferTask):
                 if "detection" in description.lower()
                 else InferType.SEGMENTATION
             )
-            if not type
-            else type
         )
 
     def _filter_transforms(self, transforms, filters):

--- a/monailabel/transform/writer.py
+++ b/monailabel/transform/writer.py
@@ -19,9 +19,9 @@ import numpy as np
 import torch
 from monai.data import MetaTensor, write_nifti
 
+from monailabel.utils.others.detection import create_slicer_detection_json
 from monailabel.utils.others.generic import file_ext
 from monailabel.utils.others.pathology import create_asap_annotations_xml, create_dsa_annotations_json
-from monailabel.utils.others.detection import create_slicer_detection_json
 
 logger = logging.getLogger(__name__)
 
@@ -310,6 +310,7 @@ class PolygonWriter:
 
         return output_file, res_json
 
+
 class DetectionWriter:
     def __init__(
         self,
@@ -338,7 +339,7 @@ class DetectionWriter:
         write_to_file = data.get(self.key_write_to_file, True)
         if not write_to_file:
             return None, output_json
-            
+
         res_json = {
             "name": f"MONAILabel Annotations - {data.get('model')}",
             "description": data.get("description"),

--- a/monailabel/utils/others/detection.py
+++ b/monailabel/utils/others/detection.py
@@ -1,0 +1,83 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import tempfile
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_slicer_detection_json(json_data, loglevel="INFO"):
+    logger.setLevel(loglevel.upper())
+
+    total_count = 0
+
+    item = json_data["box"][0] # return highest prob box #TODO: return multiple boxes.
+
+    center = item[0:3]
+    size = item[3:]
+    orientation = [-1.0, -0.0, -0.0, -0.0, -1.0, -0.0, 0.0, 0.0, 1.0]
+    label = json_data["label"][0]
+
+    label_json = tempfile.NamedTemporaryFile(suffix=".json").name
+
+    with open(label_json, "w") as fp:
+        fp.write("{\n")
+        fp.write(' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n')
+
+        fp.write(' "markups": [\n')
+
+        control_points = {
+            "id": "1",
+            "label": "ROI",
+            "description": "",
+            "associatedNodeID": "vtkMRMLScalarVolumeNode1",
+            "position": center,
+            "orientation": orientation,
+            "selected": True,
+            "locked": False,
+            "visibility": True,
+            "positionStatus": "defined"                
+        }
+        measurements = {
+                "name": "volume",
+                "enabled": False,
+                "units": "cm3",
+                "printFormat": "%-#4.4g%s"                
+        }
+        detection_node = {
+            "name": json_data["image"].split("/")[-1],
+            "type": "ROI",
+            "coordinateSystem": "LPS", # use LPS coordinate system by default, which is defined by the bundle
+            "coordinateUnits": "mm",
+            "locked": False,
+            "fixedNumberOfControlPoints": False,
+            "labelFormat": "%N-%d",
+            "lastUsedControlPointNumber": 1,
+            "roiType": "Box",
+            "center": center,
+            "orientation": orientation,
+            "size": size,
+            "insideOut": False,
+            "label": {"value": label},
+            "controlPoints": [control_points],
+            "measurements": [measurements]
+        }
+        fp.write(f"  {json.dumps(detection_node)}")
+
+        fp.write("]\n")  # close elements
+        fp.write("}")  # end of root
+
+    logger.info(f"Total Elements: {total_count}")
+    return label_json, total_count
+

--- a/monailabel/utils/others/detection.py
+++ b/monailabel/utils/others/detection.py
@@ -13,7 +13,6 @@ import json
 import logging
 import tempfile
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +21,7 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
 
     total_count = 0
 
-    item = json_data["box"][0] # return highest prob box #TODO: return multiple boxes.
+    item = json_data["box"][0]  # return highest prob box #TODO: return multiple boxes.
 
     center = item[0:3]
     size = item[3:]
@@ -33,7 +32,9 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
 
     with open(label_json, "w") as fp:
         fp.write("{\n")
-        fp.write(' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n')
+        fp.write(
+            ' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n'
+        )
 
         fp.write(' "markups": [\n')
 
@@ -47,18 +48,13 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
             "selected": True,
             "locked": False,
             "visibility": True,
-            "positionStatus": "defined"                
+            "positionStatus": "defined",
         }
-        measurements = {
-                "name": "volume",
-                "enabled": False,
-                "units": "cm3",
-                "printFormat": "%-#4.4g%s"                
-        }
+        measurements = {"name": "volume", "enabled": False, "units": "cm3", "printFormat": "%-#4.4g%s"}
         detection_node = {
             "name": json_data["image"].split("/")[-1],
             "type": "ROI",
-            "coordinateSystem": "LPS", # use LPS coordinate system by default, which is defined by the bundle
+            "coordinateSystem": "LPS",  # use LPS coordinate system by default, which is defined by the bundle
             "coordinateUnits": "mm",
             "locked": False,
             "fixedNumberOfControlPoints": False,
@@ -71,7 +67,7 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
             "insideOut": False,
             "label": {"value": label},
             "controlPoints": [control_points],
-            "measurements": [measurements]
+            "measurements": [measurements],
         }
         fp.write(f"  {json.dumps(detection_node)}")
 
@@ -80,4 +76,3 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
 
     logger.info(f"Total Elements: {total_count}")
     return label_json, total_count
-

--- a/monailabel/utils/others/modelzoo_list.py
+++ b/monailabel/utils/others/modelzoo_list.py
@@ -23,11 +23,12 @@ Note: Version tags are not needed.
 """
 
 MAINTAINED_BUNDLES = [
-    "pancreas_ct_dints_segmentation",  # Pancreas segmentation with radiology/monaibundle app support
-    "prostate_mri_anatomy",  # prostate segmentation with radiology/monaibundle app support
-    "renalStructures_UNEST_segmentation",  # renal cortex, medulla, pelvis segmentation with radiology/monaibundle support
-    "spleen_ct_segmentation",  # spleen segmentation with radiology/monaibundle support
-    "spleen_deepedit_annotation",  # spleen deepedit model annotation for CT images
-    "swin_unetr_btcv_segmentation",  # 3D transformer model for multi-organ segmentation
-    "wholeBrainSeg_Large_UNEST_segmentation",  # whole brain segmentation for T1 MRI brain images.
+    "pancreas_ct_dints_segmentation",  # Pancreas segmentation with radiology/monaibundle app support. Added Oct 2022
+    "prostate_mri_anatomy",  # prostate segmentation with radiology/monaibundle app support. Added Oct 2022
+    "renalStructures_UNEST_segmentation",  # renal cortex, medulla, pelvis segmentation with radiology/monaibundle support. Added Oct 2022
+    "spleen_ct_segmentation",  # spleen segmentation with radiology/monaibundle support. Added Oct 2022
+    "spleen_deepedit_annotation",  # spleen deepedit model annotation for CT images. Added Oct 2022
+    "swin_unetr_btcv_segmentation",  # 3D transformer model for multi-organ segmentation. Added Oct 2022
+    "wholeBrainSeg_Large_UNEST_segmentation",  # whole brain segmentation for T1 MRI brain images. Added Oct 2022
+    "lung_nodule_ct_detection"  # The first lung nodule detection task can be used for MONAI Label. Added Dec 2022
 ]

--- a/monailabel/utils/others/modelzoo_list.py
+++ b/monailabel/utils/others/modelzoo_list.py
@@ -30,5 +30,5 @@ MAINTAINED_BUNDLES = [
     "spleen_deepedit_annotation",  # spleen deepedit model annotation for CT images. Added Oct 2022
     "swin_unetr_btcv_segmentation",  # 3D transformer model for multi-organ segmentation. Added Oct 2022
     "wholeBrainSeg_Large_UNEST_segmentation",  # whole brain segmentation for T1 MRI brain images. Added Oct 2022
-    "lung_nodule_ct_detection"  # The first lung nodule detection task can be used for MONAI Label. Added Dec 2022
+    "lung_nodule_ct_detection",  # The first lung nodule detection task can be used for MONAI Label. Added Dec 2022
 ]

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -522,11 +522,11 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.ui.uploadImageButton.setEnabled(self.current_sample and self.current_sample.get("session"))
 
-        self.updateSelector(self.ui.segmentationModelSelector, ["segmentation"], "SegmentationModel", 0)
+        self.updateSelector(self.ui.segmentationModelSelector, ["segmentation", "detection"], "SegmentationModel", 0)
         self.updateSelector(self.ui.deepgrowModelSelector, ["deepgrow", "deepedit"], "DeepgrowModel", 0)
         self.updateSelector(self.ui.scribblesMethodSelector, ["scribbles"], "ScribblesMethod", 0)
 
-        if self.models and [k for k, v in self.models.items() if v["type"] == "segmentation"]:
+        if self.models and [k for k, v in self.models.items() if v["type"] in ("segmentation", "detection")]:
             self.ui.segmentationCollapsibleButton.collapsed = False
             self.ui.segmentationCollapsibleButton.show()
         else:
@@ -1673,6 +1673,12 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 destination_node.SetReferenceImageGeometryParameterFromVolumeNode(self._volumeNode)
 
             slicer.mrmlScene.RemoveNode(source_node)
+        elif in_file.endswith(".json"):
+            # Add bounding box ROI node 
+            logging.info("Update Detection ROI Bounding Box")
+            detectionROINode = slicer.util.loadMarkups(in_file)
+            detectionROINode.SetName('Detection ROI')
+            detectionROINode.GetDisplayNode().SetInteractionHandleScale(0.7)
         else:
             labels = [label for label in labels if label != "background"]
             logging.info(f"Update Segmentation Mask using Labels: {labels}")

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1674,10 +1674,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
             slicer.mrmlScene.RemoveNode(source_node)
         elif in_file.endswith(".json"):
-            # Add bounding box ROI node 
+            # Add bounding box ROI node
             logging.info("Update Detection ROI Bounding Box")
             detectionROINode = slicer.util.loadMarkups(in_file)
-            detectionROINode.SetName('Detection ROI')
+            detectionROINode.SetName("Detection ROI")
             detectionROINode.GetDisplayNode().SetInteractionHandleScale(0.7)
         else:
             labels = [label for label in labels if label != "background"]


### PR DESCRIPTION
This PR adds detection task support for MONAI Label.

Inference pipeline supported. 

Feature:

MONAI Label + 3D Slicer for detection annotation.

How to start: 

- User can try the inference with MSD Task06 Lung nodule dataset:

`monailabel datasets --download --name Task06_Lung --output .
`
- Then start monailabel server: 
`monailabel start_server --app sample-apps/monaibundle/ --studies Task06_Lung/imagesTr --conf models lung_nodule_ct_detection_v0.5.0`

- Use the new MONAI Label Slicer plugin and developer mode to load plugin. 

Inference result and display as Box ROI in Slicer: 

![detection_demo](https://user-images.githubusercontent.com/58751975/205853068-0db010a8-5aec-467c-a6a3-3447ee2265b9.png)

Video demo for a usecase: https://drive.google.com/file/d/1UXIht9x7vUM9P_JGIAhBp_Bg6_BfCG7j/view?usp=share_link


Some note:

- Latest detection bundle: `**lung_nodule_ct_detection_v0.5.0**` is used for development.
- A "detector" function is used, as the detector is a wrapper function of inferer, so treated the detector as a separate InferType. 
- run_detector function should accommodate detection task data format, and wrap network, RetinaInferer, box selector in detector.
- DetectionWriter is for generating detection result json.
- create_slicer_detection_json is used for adapting 3d Slicer MarkupsROINode.
- Tested latest repo with integration test, tested several latest maintained bundles. 


