### PR TITLE
Add Unit Tests to Improve Coverage | transforms | 1

### DIFF
--- a/tests/unit/transform/test_post.py
+++ b/tests/unit/transform/test_post.py
@@ -9,12 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
-
+import tempfile
 import numpy as np
 from parameterized import parameterized
 
-from monailabel.transform.post import BoundingBoxd, ExtremePointsd, LargestCCd, Restored
+from monailabel.transform.post import BoundingBoxd, ExtremePointsd, LargestCCd, Restored, FindContoursd, DumpImagePrediction2Dd, MergeAllPreds, RenameKeyd
 
 CCD_DATA = [
     {"keys": ("pred",)},
@@ -45,6 +46,34 @@ RESTORED_DATA = [
     (1, 6, 6),
 ]
 
+FINDCONTOURSD_DATA = [
+    {"keys": "pred", "labels": "Other", "min_positive": 4, "min_poly_area": 1},
+    {
+        "pred": np.array([[0, 0, 0, 0, 0], [0, 1, 1, 1, 0], [0, 1, 0, 1, 0], [0, 1, 1, 1, 0], [0, 0, 0, 0, 0]]),
+    },
+    [[[1, 2], [2, 1], [3, 2], [2, 3]], [[1, 1], [1, 3], [3, 3], [3, 1]]],
+]
+
+DUMPIMAGEPREDICTION2DD_DATA = [
+    {
+        "image": np.random.rand(1, 3, 5, 5),
+        "pred": np.random.rand(1, 5, 5),
+    },
+]
+
+METGEAllPREDS_DATA = [
+    {"keys": ["pred", "pred_2"]},
+    {
+        "pred": np.array([[[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 0]]]),
+        "pred_2": np.array([[[1, 0, 0, 1], [1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]]),
+    },
+    [[[1, 0, 0, 1], [1, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 1]]],
+]
+
+RENAMEKEY_DATA = [
+    {"source_key": "pred", "target_key": "pred_2"},
+    {"pred": np.array([[[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])},
+]
 
 class TestLargestCCd(unittest.TestCase):
     @parameterized.expand([CCD_DATA])
@@ -52,13 +81,11 @@ class TestLargestCCd(unittest.TestCase):
         res = LargestCCd(**args)(input_data)
         np.testing.assert_equal(res["pred"], expected_output)
 
-
 class TestExtremePointsd(unittest.TestCase):
     @parameterized.expand([EXTREME_POINTS_DATA])
     def test_result(self, args, input_data, expected_data):
         res = ExtremePointsd(**args)(input_data)
         self.assertEqual(res["result"]["points"], expected_data)
-
 
 class TestBoundingBoxd(unittest.TestCase):
     @parameterized.expand([BB_DATA])
@@ -66,13 +93,39 @@ class TestBoundingBoxd(unittest.TestCase):
         res = BoundingBoxd(**args)(input_data)
         self.assertEqual(res["result"]["bbox"], expected_data)
 
-
 class TestRestored(unittest.TestCase):
     @parameterized.expand([RESTORED_DATA])
     def test_result(self, args, input_data, expected_shape):
         res = Restored(**args)(input_data)
         self.assertEqual(res["pred"].shape, expected_shape)
 
+class TestFindContoursd(unittest.TestCase):
+    @parameterized.expand([FINDCONTOURSD_DATA])
+    def test_result(self, args, input_data, expected_output):
+        res = FindContoursd(**args)(input_data)
+        self.assertEqual(res["result"]["annotation"]["elements"][0]["contours"], expected_output)
+
+class TestDumpImagePrediction2Dd(unittest.TestCase):
+    @parameterized.expand([DUMPIMAGEPREDICTION2DD_DATA])
+    def test_saved_content(self, input_data):
+        with tempfile.TemporaryDirectory() as tempdir:
+            image_path = os.path.join(tempdir, "testimage.png")
+            pred_path = os.path.join(tempdir, "testpred.png")
+            _ = DumpImagePrediction2Dd(image_path=image_path, pred_path=pred_path, pred_only=False)(input_data)
+            self.assertTrue(os.path.exists(image_path))
+            self.assertTrue(os.path.exists(pred_path))
+
+class TestMergeAllPreds(unittest.TestCase):
+    @parameterized.expand([METGEAllPREDS_DATA])
+    def test_merge_pred(self, args, input_data, expected_output):
+        res = MergeAllPreds(**args)(input_data)
+        self.assertEqual(res.tolist(), expected_output)
+
+class TestRenameKeyd(unittest.TestCase):
+    @parameterized.expand([RENAMEKEY_DATA])
+    def test_rename_key(self, args, input_data):
+        res = RenameKeyd(**args)(input_data)
+        self.assertEqual(list(res.keys())[0], args["target_key"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/transform/test_pre.py
+++ b/tests/unit/transform/test_pre.py
@@ -1,0 +1,57 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+import numpy as np
+import nibabel as nib
+import tempfile
+from parameterized import parameterized
+
+from monailabel.transform.pre import LoadImageTensord, LoadImageExd, NormalizeLabeld
+
+
+LOADIMAGETENSOR_DATA = [
+    {"keys": "image"},
+    {
+        "image": np.random.rand(64, 64, 64),
+    },
+    (64, 64, 64),
+]
+
+NORMALIZELABELD_DATA = [
+    {"keys": "label"},
+    {
+        "label": np.array([[[0, 0, 0, 0], [0, 5, 4, 0], [0, 3, 2, 0], [0, 1, 0, 0]]]),
+    },
+    [[[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 1, 0, 0]]],
+]
+
+class TestLoadImageTensord(unittest.TestCase):
+    @parameterized.expand([LOADIMAGETENSOR_DATA])
+    def test_load_image_shape(self, args, input_data, expected_shape):
+        res = LoadImageTensord(**args)(input_data)
+        self.assertTupleEqual(res["image"].shape, expected_shape)
+
+class TestLoadImageExd(unittest.TestCase):
+    @parameterized.expand([LOADIMAGETENSOR_DATA])
+    def test_load_imageEx_shape(self, args, input_data, expected_shape):
+        res = LoadImageExd(**args)(input_data)
+        self.assertTupleEqual(res["image"].shape, expected_shape)
+
+class TestNormalizeLabeld(unittest.TestCase):
+    @parameterized.expand([NORMALIZELABELD_DATA])
+    def test_result(self, args, input_data, expected_data):
+        res = NormalizeLabeld(**args)(input_data)
+        self.assertEqual(res["label"].tolist(), expected_data)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/transform/test_writer.py
+++ b/tests/unit/transform/test_writer.py
@@ -12,12 +12,13 @@
 import os
 import pathlib
 import unittest
-
+import json
+import torch
 import nrrd
 import numpy as np
 from parameterized import parameterized
 
-from monailabel.transform.writer import Writer
+from monailabel.transform.writer import Writer, PolygonWriter, DetectionWriter
 
 WRITER_DATA = [
     {"label": "pred"},
@@ -40,6 +41,44 @@ COLOR_MAP = {
     "lung": [128 / 255, 174 / 255, 128 / 255],  # green
     "heart": [206 / 255, 110 / 255, 84 / 255],  # red
 }
+
+
+POLYGONWRITER_DATA = [
+    {"label": "pred"},
+    {
+        "pred": np.array([[[1, 0, 1, 0], [0, 0, 1, 0], [0, 0, 1, 0]]]).astype(np.float32),
+        "pred_meta_dict": {
+            "affine": np.identity(4),
+        },
+        "image_path": "fakepath.nii",
+        "output": "asap",
+        'result': {'annotation': {'location': (2263, 5298), 'size': (55, 44), 'elements': [{'label': 'Inflammatory', 'contours': [
+            [[2299, 5298], [2299, 5301], [2302, 5301], [2303, 5302], [2304, 5302], [2308, 5306], [2308, 5307], [2309, 5307], [2310, 5308], \
+                [2311, 5307], [2314, 5307], [2315, 5306], [2316, 5307], [2316, 5306], [2317, 5305], [2317, 5298]]
+            ]}], 'labels': {'Inflammatory': (255, 255, 0), 'Spindle-Shaped': (0, 255, 0)}}},
+    },
+]
+
+
+DETECTION_DATA = [
+    {"pred_box_key": "box", "pred_label_key": "label"},
+    {
+        "pred": np.array([[[1, 0, 1, 0], [0, 0, 1, 0], [0, 0, 1, 0]]]).astype(np.float32),
+        "pred_meta_dict": {
+            "affine": np.identity(4),
+        },
+        "image_path": "fakepath.nii",
+        'box': torch.tensor([[  37.5524, -153.9518, -230.8054,    8.1992,    8.1875,    8.2574],
+                [-112.3948, -160.7483, -192.0955,    4.8497,    4.7852,    4.8144],
+                [  -8.1750, -187.5624,  -48.9165,    7.0694,    7.0703,    6.5331],
+                [ -98.9357, -225.9962, -176.4017,    4.5932,    4.6513,    4.4018],
+                [ -95.4652, -132.0942, -159.3038,    4.4789,    4.3853,    4.5687],
+                [ -69.8407, -195.1670, -102.0295,    4.2224,    4.2135,    4.2672],
+                [ -46.4637, -170.2633,  -75.5516,   16.6934,   16.4776,   16.7486],
+                [ -61.1737, -222.7262, -130.8002,    8.5873,    8.4749,    8.4555]]),
+        'label': torch.tensor([0, 0, 0, 0, 0, 0, 0, 0])
+    },
+]
 
 
 class TestWriter(unittest.TestCase):
@@ -88,6 +127,44 @@ class TestWriter(unittest.TestCase):
         file_ext = "".join(pathlib.Path(input_data["image_path"]).suffixes)
         self.assertIn(file_ext.lower(), [".nii", ".nii.gz"])
 
+class TestPolygonWriter(unittest.TestCase):
+    @parameterized.expand([POLYGONWRITER_DATA])
+    def test_asap_result(self, args, input_data):
+        output_file, data = PolygonWriter(**args)(input_data)
+        self.assertEqual(os.path.exists(output_file), True)
+        file_ext = "".join(pathlib.Path(input_data["image_path"]).suffixes)
+        self.assertIn(file_ext.lower(), [".nii", ".nii.gz"])
+        file_ext = "".join(pathlib.Path(output_file).suffixes)
+        self.assertIn(file_ext.lower(), [".xml"])
+
+    @parameterized.expand([POLYGONWRITER_DATA])
+    def test_dsa_result(self, args, input_data):
+        input_data.update({"output": "dsa"})
+        output_file, data = PolygonWriter(**args)(input_data)
+        self.assertEqual(os.path.exists(output_file), True)
+        file_ext = "".join(pathlib.Path(input_data["image_path"]).suffixes)
+        self.assertIn(file_ext.lower(), [".nii", ".nii.gz"])
+        file_ext = "".join(pathlib.Path(output_file).suffixes)
+        self.assertIn(file_ext.lower(), [".json"])
+
+        with open(output_file, 'r') as f:
+            data = json.load(f)
+            self.assertEqual(len(data["elements"][0]["points"]), 16)
+            self.assertEqual(data["elements"][0]["label"]["value"], "Inflammatory")
+
+class TestDetectionWriter(unittest.TestCase):
+    @parameterized.expand([DETECTION_DATA])
+    def test_slicer_result(self, args, input_data):
+        output_file, data = DetectionWriter(**args)(input_data)
+        self.assertEqual(os.path.exists(output_file), True)
+        file_ext = "".join(pathlib.Path(input_data["image_path"]).suffixes)
+        self.assertIn(file_ext.lower(), [".nii", ".nii.gz"])
+        file_ext = "".join(pathlib.Path(output_file).suffixes)
+        self.assertIn(file_ext.lower(), [".json"])
+        with open(output_file, 'r') as f:
+            data = json.load(f)
+            self.assertEqual(data["markups"][0]["center"], [37.552398681640625, -153.95179748535156, -230.80540466308594])
+            self.assertEqual(data["markups"][0]["size"], [8.199199676513672, 8.1875, 8.257399559020996])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add first batch of  UTs to improve code coverage. 

These unit tests covers "transforms" codes, for post/pre/writer.

UT coverage should be 60% now from 47.5%.

Working to add more...