### PR TITLE
Add detection train support and plugin for save detection label

### DIFF
--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -109,14 +109,14 @@ class BundleTrainTask(TrainTask):
 
     def _partition_datalist(self, datalist, request, shuffle=False):
         if "detection" in request.get("model"):
-            # Generate datalist for detection task, box and label keys are used by default. 
+            # Generate datalist for detection task, box and label keys are used by default.
             # Future: either use box and label keys for all detection models, or set these keys by config.
             for idx, d in enumerate(datalist):
                 with open(d["label"]) as fp:
-                    json_object = json.loads(fp.read()) # load box coordinates from subject JSON
+                    json_object = json.loads(fp.read())  # load box coordinates from subject JSON
                     bboxes = [bdict["center"] + bdict["size"] for bdict in json_object["markups"]]
                 # Only support detection, classification label do not suppot in bundle yet, 0 is used for all positive boxes, wait for sync.
-                datalist[idx] = {"image": d["image"], "box": bboxes, "label": [0]*len(bboxes)}
+                datalist[idx] = {"image": d["image"], "box": bboxes, "label": [0] * len(bboxes)}
         else:
             # only use image and label attributes; skip for other meta info from datastore for now
             datalist = [{"image": d["image"], "label": d["label"]} for d in datalist if d]

--- a/monailabel/utils/others/detection.py
+++ b/monailabel/utils/others/detection.py
@@ -24,7 +24,9 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
 
     with open(label_json, "w") as fp:
         fp.write("{\n")
-        fp.write(' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n')
+        fp.write(
+            ' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n'
+        )
 
         fp.write(' "markups": [\n')
 
@@ -48,18 +50,13 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
                 "selected": True,
                 "locked": False,
                 "visibility": True,
-                "positionStatus": "defined"                
+                "positionStatus": "defined",
             }
-            measurements = {
-                    "name": "volume",
-                    "enabled": False,
-                    "units": "cm3",
-                    "printFormat": "%-#4.4g%s"                
-            }
+            measurements = {"name": "volume", "enabled": False, "units": "cm3", "printFormat": "%-#4.4g%s"}
             detection_node = {
                 "name": json_data["image"].split("/")[-1],
                 "type": "ROI",
-                "coordinateSystem": "LPS", # use LPS coordinate system by default, which is defined by the bundle
+                "coordinateSystem": "LPS",  # use LPS coordinate system by default, which is defined by the bundle
                 "coordinateUnits": "mm",
                 "locked": False,
                 "fixedNumberOfControlPoints": False,
@@ -72,7 +69,7 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
                 "insideOut": False,
                 "label": {"value": label},
                 "controlPoints": [control_points],
-                "measurements": [measurements]
+                "measurements": [measurements],
             }
             fp.write(f"  {json.dumps(detection_node)}")
             total_count += 1

--- a/monailabel/utils/others/detection.py
+++ b/monailabel/utils/others/detection.py
@@ -20,56 +20,62 @@ def create_slicer_detection_json(json_data, loglevel="INFO"):
     logger.setLevel(loglevel.upper())
 
     total_count = 0
-
-    item = json_data["box"][0]  # return highest prob box #TODO: return multiple boxes.
-
-    center = item[0:3]
-    size = item[3:]
-    orientation = [-1.0, -0.0, -0.0, -0.0, -1.0, -0.0, 0.0, 0.0, 1.0]
-    label = json_data["label"][0]
-
     label_json = tempfile.NamedTemporaryFile(suffix=".json").name
 
     with open(label_json, "w") as fp:
         fp.write("{\n")
-        fp.write(
-            ' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n'
-        )
+        fp.write(' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n')
 
         fp.write(' "markups": [\n')
 
-        control_points = {
-            "id": "1",
-            "label": "ROI",
-            "description": "",
-            "associatedNodeID": "vtkMRMLScalarVolumeNode1",
-            "position": center,
-            "orientation": orientation,
-            "selected": True,
-            "locked": False,
-            "visibility": True,
-            "positionStatus": "defined",
-        }
-        measurements = {"name": "volume", "enabled": False, "units": "cm3", "printFormat": "%-#4.4g%s"}
-        detection_node = {
-            "name": json_data["image"].split("/")[-1],
-            "type": "ROI",
-            "coordinateSystem": "LPS",  # use LPS coordinate system by default, which is defined by the bundle
-            "coordinateUnits": "mm",
-            "locked": False,
-            "fixedNumberOfControlPoints": False,
-            "labelFormat": "%N-%d",
-            "lastUsedControlPointNumber": 1,
-            "roiType": "Box",
-            "center": center,
-            "orientation": orientation,
-            "size": size,
-            "insideOut": False,
-            "label": {"value": label},
-            "controlPoints": [control_points],
-            "measurements": [measurements],
-        }
-        fp.write(f"  {json.dumps(detection_node)}")
+        for idx, item in enumerate(json_data["box"]):
+
+            center = item[0:3]
+            size = item[3:]
+            orientation = [-1.0, -0.0, -0.0, -0.0, -1.0, -0.0, 0.0, 0.0, 1.0]
+            label = json_data["label"][idx]
+
+            if total_count > 0:
+                fp.write(",\n")
+
+            control_points = {
+                "id": "1",
+                "label": "ROI",
+                "description": "",
+                "associatedNodeID": "vtkMRMLScalarVolumeNode1",
+                "position": center,
+                "orientation": orientation,
+                "selected": True,
+                "locked": False,
+                "visibility": True,
+                "positionStatus": "defined"                
+            }
+            measurements = {
+                    "name": "volume",
+                    "enabled": False,
+                    "units": "cm3",
+                    "printFormat": "%-#4.4g%s"                
+            }
+            detection_node = {
+                "name": json_data["image"].split("/")[-1],
+                "type": "ROI",
+                "coordinateSystem": "LPS", # use LPS coordinate system by default, which is defined by the bundle
+                "coordinateUnits": "mm",
+                "locked": False,
+                "fixedNumberOfControlPoints": False,
+                "labelFormat": "%N-%d",
+                "lastUsedControlPointNumber": 1,
+                "roiType": "Box",
+                "center": center,
+                "orientation": orientation,
+                "size": size,
+                "insideOut": False,
+                "label": {"value": label},
+                "controlPoints": [control_points],
+                "measurements": [measurements]
+            }
+            fp.write(f"  {json.dumps(detection_node)}")
+            total_count += 1
 
         fp.write("]\n")  # close elements
         fp.write("}")  # end of root

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1683,13 +1683,13 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             # Add bounding box ROI nodes, load multiple ROI nodes in the same scene.
             logging.info("Update Detection ROI Bounding Box")
             slicer.util.loadMarkups(in_file)
-            detectionROIs = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsROINode") # Get all ROI node from scene
+            detectionROIs = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsROINode")  # Get all ROI node from scene
             numNodes = detectionROIs.GetNumberOfItems()
             for i in range(numNodes):
                 ROINode = detectionROIs.GetItemAsObject(i)
                 if ROINode.GetName() != "Scribbles ROI":
-                    ROINode.SetName('Detection ROI - {}'.format(i))
-                    ROINode.GetDisplayNode().SetInteractionHandleScale(0.7) # set handle size
+                    ROINode.SetName(f"Detection ROI - {i}")
+                    ROINode.GetDisplayNode().SetInteractionHandleScale(0.7)  # set handle size
         else:
             labels = [label for label in labels if label != "background"]
             logging.info(f"Update Segmentation Mask using Labels: {labels}")
@@ -2112,7 +2112,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onGenerateJSONFromMulipltROIs(self):
         """
-        The functon to generate output JSON label fils with multiple ROI nodes. 
+        The functon to generate output JSON label fils with multiple ROI nodes.
         """
         detectionROIs = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsROINode")
         numNodes = detectionROIs.GetNumberOfItems()
@@ -2121,7 +2121,9 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         total_count = 0
         with open(label_in, "w") as fp:
             fp.write("{\n")
-            fp.write(' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n')
+            fp.write(
+                ' "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json#",\n'
+            )
             fp.write(' "markups": [\n')
             for i in range(numNodes):
                 ROINode = detectionROIs.GetItemAsObject(i)
@@ -2140,7 +2142,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             fp.write("}")  # end of root
         label_info = []
         return label_in, label_info
-        
+
+
 class MONAILabelLogic(ScriptedLoadableModuleLogic):
     def __init__(self, tmpdir=None, server_url=None, progress_callback=None, client_id=None):
         ScriptedLoadableModuleLogic.__init__(self)


### PR DESCRIPTION
Add code for detection task training support, including:

1. After inference, add "save label" logic to submit detection ROI JSON file to "final", one JSON file per subject. The JSON file can be reload into 3D Slice for further annotation.
2. Modify detection writer to create Slicer compatible ROI node JSON objects, multiple nodes per JSON, support loading multiple ROI node from single markups JSON.
3. Add training logic: create detection task datalist to load files for training pipeline. 

E2E inference+Training video demo: 

Workflow:

https://drive.google.com/file/d/1gxhGr81TRS0-NJ4hv0tkt8fg1Rlw0aX_/view?usp=share_link