### PR TITLE
flag to disable default mlflow tracking

### DIFF
--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -77,6 +77,7 @@ class Settings(BaseSettings):
 
     MONAI_LABEL_INFER_CONCURRENCY: int = -1
     MONAI_LABEL_INFER_TIMEOUT: int = 600
+    MONAI_LABEL_TRACKING_ENABLED: bool = True
     MONAI_LABEL_TRACKING_URI: str = ""
 
     class Config:

--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -310,6 +310,7 @@ class BasicTrainTask(TrainTask):
                         run_name=context.tracking_run_name,
                         iteration_log=True,
                         output_transform=from_engine(["loss"], first=True),
+                        close_on_complete=True,
                     )
                 )
 
@@ -347,6 +348,7 @@ class BasicTrainTask(TrainTask):
                     experiment_name=context.tracking_experiment_name,
                     run_name=context.tracking_run_name,
                     iteration_log=False,
+                    close_on_complete=True,
                 )
             )
         return handlers if context.local_rank == 0 else None

--- a/monailabel/tasks/train/basic_train.py
+++ b/monailabel/tasks/train/basic_train.py
@@ -123,7 +123,7 @@ class BasicTrainTask(TrainTask):
         load_strict=False,
         labels=None,
         disable_meta_tracking=False,
-        tracking="mlflow",
+        tracking="mlflow" if settings.MONAI_LABEL_TRACKING_ENABLED else None,
         tracking_uri=settings.MONAI_LABEL_TRACKING_URI,
         tracking_experiment_name=None,
     ):
@@ -167,7 +167,7 @@ class BasicTrainTask(TrainTask):
             "gpus": "all",
             "dataset": ["SmartCacheDataset", "CacheDataset", "PersistentDataset", "Dataset"],
             "dataloader": ["ThreadDataLoader", "DataLoader"],
-            "tracking": ["mlflow", "None"],
+            "tracking": ["mlflow", "None"] if settings.MONAI_LABEL_TRACKING_ENABLED else ["None", "mlflow"],
             "tracking_uri": tracking_uri if tracking_uri else "",
             "tracking_experiment_name": "",
         }
@@ -510,6 +510,7 @@ class BasicTrainTask(TrainTask):
         context.output_dir = os.path.join(self._model_dir, name)
         context.cache_dir = os.path.join(context.output_dir, f"cache_{context.run_id}")
         context.events_dir = os.path.join(context.output_dir, f"events_{context.run_id}")
+        logger.info(f"Run/Output Path: {context.output_dir}")
 
         tracking_uri = request.get("tracking_uri", self._tracking_uri)
         if not tracking_uri:
@@ -525,7 +526,7 @@ class BasicTrainTask(TrainTask):
         context.tracking_experiment_name = experiment_name
         context.tracking_run_name = run_name
 
-        logger.info(f"Run/Output Path: {context.output_dir}")
+        logger.info(f"Tracking: {context.tracking} ")
         logger.info(f"Tracking URI: {context.tracking_uri}; ")
         logger.info(f"Tracking Experiment Name: {experiment_name}; Run Name: {run_name}")
 

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -115,7 +115,7 @@ class BundleTrainTask(TrainTask):
             "val_split": 0.2,  # VALIDATION SPLIT; -1 TO USE DEFAULT FROM BUNDLE
             "multi_gpu": True,  # USE MULTI-GPU
             "gpus": "all",  # COMMA SEPARATE DEVICE INDEX
-            "tracking": ["mlflow", "None"],
+            "tracking": ["mlflow", "None"] if settings.MONAI_LABEL_TRACKING_ENABLED else ["None", "mlflow"],
             "tracking_uri": settings.MONAI_LABEL_TRACKING_URI,
             "tracking_experiment_name": "",
         }
@@ -186,7 +186,7 @@ class BundleTrainTask(TrainTask):
         device = request.get("device", "cuda")
         logger.info(f"Using device: {device}; Type: {type(device)}")
 
-        tracking = request.get("tracking", "mlflow")
+        tracking = request.get("tracking", "mlflow" if settings.MONAI_LABEL_TRACKING_ENABLED else "")
         tracking = tracking[0] if isinstance(tracking, list) else tracking
         tracking_uri = request.get("tracking_uri")
         tracking_uri = tracking_uri if tracking_uri else settings.MONAI_LABEL_TRACKING_URI


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

```bash
export MONAI_LABEL_TRACKING_ENABLED=false
# start monailabel server to disable the tracking by default
# however user can send traking "mlflow" to enable for his/her workflow per train request
```