### PR TITLE
Fix KeyError in Slicer extension

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1399,7 +1399,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
             model = self.ui.segmentationModelSelector.currentText
 
-            if self.models[model]["type"] == "detection":
+            if model and self.models[model]["type"] == "detection":
                 label_in, label_info = self.onGenerateJSONFromMulipltROIs()
                 self.reportProgress(30)
             else:


### PR DESCRIPTION
This PR fixes a minor issue in the Slicer extension.

In case a MONAILabel app is used without an inferer/without a pre-trained model (annotations from scratch) it is not possible to save new labels in Slicer because a KeyError is thrown:

```
Traceback (most recent call last):
  File "/Applications/Slicer.app/Contents/Extensions-31317/MONAILabel/lib/Slicer-5.2/qt-scripted-modules/MONAILabel.py", line 1402, in onSaveLabel
    if self.models[model]["type"] == "detection":
KeyError: ''
```