### PR TITLE
Fix manually imported pre-segmentations are not auto-loaded by Slicer plugin

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1263,8 +1263,17 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             if slicer.util.settingsValue("MONAILabel/originalLabel", True, converter=slicer.util.toBool):
                 try:
                     datastore = self.logic.datastore()
-                    labels = datastore["objects"][image_id]["labels"]["original"]["info"]["params"]["label_names"]
-                    labels = labels.keys()
+                    label_info = datastore["objects"][image_id]["labels"]["original"]["info"]
+                    labels = label_info.get ("params", {}).get("label_names", {})
+                    
+                    if labels:
+                        # labels are available in original label info
+                        labels = labels.keys()
+                    else:
+                        # labels not available
+                        # assume labels in app info are valid for original label file
+                        labels = self.logic.info().get("labels")
+                        
                     # ext = datastore['objects'][image_id]['labels']['original']['ext']
                     maskFile = self.logic.download_label(image_id, "original")
                     self.updateSegmentationMask(maskFile, list(labels))

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1264,8 +1264,8 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 try:
                     datastore = self.logic.datastore()
                     label_info = datastore["objects"][image_id]["labels"]["original"]["info"]
-                    labels = label_info.get ("params", {}).get("label_names", {})
-                    
+                    labels = label_info.get("params", {}).get("label_names", {})
+
                     if labels:
                         # labels are available in original label info
                         labels = labels.keys()
@@ -1273,7 +1273,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         # labels not available
                         # assume labels in app info are valid for original label file
                         labels = self.logic.info().get("labels")
-                        
+
                     # ext = datastore['objects'][image_id]['labels']['original']['ext']
                     maskFile = self.logic.download_label(image_id, "original")
                     self.updateSegmentationMask(maskFile, list(labels))


### PR DESCRIPTION
When manually copying externally created pre-segmentation files into the `labels/original` folder these files get parsed and imported into the datastore. Unfortunately, these pre-segmentations are then not read into Slicer during `onNextSampleButton()` although in Slicer's MONAILabel settings "Original Labels" is checked. This is caused by missing meta data which the Slicer plugin expects. The meta data (label list) is only created during `batch_infer()`.

My PR gets the label list from the app info (assuming that it is valid) in case an original label file is found but no corresponding label info is available. Subsequently the previously manually imported pre-segmentation gets loaded into Slicer.

