### PR TITLE
Load Config Options from Bundle

### DIFF
--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -269,7 +269,7 @@ class BasicInferTask(InferTask):
 
         # model options
         self.path.append(
-           os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))
+            os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))
         ) if self.path and isinstance(self.path, list) else self.path
 
         # device

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -267,6 +267,9 @@ class BasicInferTask(InferTask):
         req = copy.deepcopy(self._config)
         req.update(request)
 
+        # model options
+        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("models", "model.pt")))
+        
         # device
         device = req.get("device", "cuda")
         device = device if isinstance(device, str) else device[0]

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -268,7 +268,9 @@ class BasicInferTask(InferTask):
         req.update(request)
 
         # model options
-        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list) else self.path
+        self.path.append(
+           os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))
+        ) if self.path and isinstance(self.path, list) else self.path
 
         # device
         device = req.get("device", "cuda")

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -268,7 +268,7 @@ class BasicInferTask(InferTask):
         req.update(request)
 
         # model options
-        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("models", "model.pt")))
+        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt")))
 
         # device
         device = req.get("device", "cuda")

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -268,7 +268,7 @@ class BasicInferTask(InferTask):
         req.update(request)
 
         # model options
-        self.path = self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list) else []
+        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list)
 
         # device
         device = req.get("device", "cuda")

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -268,7 +268,7 @@ class BasicInferTask(InferTask):
         req.update(request)
 
         # model options
-        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt")))
+        self.path = self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list) else []
 
         # device
         device = req.get("device", "cuda")

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -268,7 +268,7 @@ class BasicInferTask(InferTask):
         req.update(request)
 
         # model options
-        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list)
+        self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("model_filename", "model.pt"))) if isinstance(self.path, list) else self.path
 
         # device
         device = req.get("device", "cuda")

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -269,7 +269,7 @@ class BasicInferTask(InferTask):
 
         # model options
         self.path.append(os.path.join(os.path.dirname(self.path[0]), req.get("models", "model.pt")))
-        
+
         # device
         device = req.get("device", "cuda")
         device = device if isinstance(device, str) else device[0]

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -151,11 +151,11 @@ class BundleInferTask(BasicInferTask):
             **kwargs,
         )
 
-        # Add models and param optiom to infer option panel
+        # Add models options if more than one model is provided by bundle.
         pytorch_models = [os.path.basename(p) for p in glob.glob(os.path.join(path, "models", "*.pt"))]
         pytorch_models.sort(key=len)
         self._config.update({"models": pytorch_models})
-        # Add bundle's loadable params to MONAI Label config
+        # Add bundle's loadable params to MONAI Label config, load exposed keys and params to options panel
         for k in self.const.key_loadable_configs():
             self.loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
             self._config.update(self.loadable_configs)

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -9,12 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import json
 import logging
 import os
 import sys
 from typing import Any, Callable, Dict, Optional, Sequence, Union
-import glob
 
 from monai.bundle import ConfigItem, ConfigParser
 from monai.inferers import Inferer, SimpleInferer
@@ -69,6 +69,7 @@ class BundleConstants:
 
     def key_loadable_configs(self) -> Sequence[str]:
         return ["loadable_params"]
+
 
 class BundleInferTask(BasicInferTask):
     """
@@ -135,7 +136,7 @@ class BundleInferTask(BasicInferTask):
         description = metadata.get("description")
         spatial_shape = image.get("spatial_shape")
         dimension = len(spatial_shape) if spatial_shape else 3
-        type = self._get_type(os.path.basename(path), type) 
+        type = self._get_type(os.path.basename(path), type)
 
         # if detection task, set post restore to False by default.
         self.add_post_restore = False if type == "detection" else add_post_restore
@@ -157,7 +158,9 @@ class BundleInferTask(BasicInferTask):
         self._config.update({"models": pytorch_models})
         # Add bundle's loadable params to MONAI Label config, load exposed keys and params to options panel
         for k in self.const.key_loadable_configs():
-            self.loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
+            self.loadable_configs = (
+                {p: self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
+            )
             self._config.update(self.loadable_configs)
 
         self.valid = True
@@ -174,8 +177,8 @@ class BundleInferTask(BasicInferTask):
 
     def pre_transforms(self, request, data=None) -> Sequence[Callable]:
         # Update bundle parameters based on user's option
-        self.bundle_config.update({k:request[k] for k in self.loadable_configs.keys()}) 
-        
+        self.bundle_config.update({k: request[k] for k in self.loadable_configs.keys()})
+
         sys.path.insert(0, self.bundle_path)
         unload_module("scripts")
         self._update_device(data)

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 from typing import Dict, Optional, Sequence
+import glob
 
 import monai.bundle
 import torch
@@ -79,6 +80,8 @@ class BundleConstants:
     def key_run_name(self) -> str:
         return "run_name"
 
+    def key_loadable_configs(self) -> Sequence[str]:
+        return ["loadable_params"]
 
 class BundleTrainTask(TrainTask):
     def __init__(
@@ -127,7 +130,11 @@ class BundleTrainTask(TrainTask):
         return i
 
     def config(self):
-        return {
+        # Add models and param optiom to infer option panel
+        pytorch_models = [os.path.basename(p) for p in glob.glob(os.path.join(self.bundle_path, "models", "*.pt"))]
+        pytorch_models.sort(key=len)
+
+        config_options = {
             "device": "cuda",  # DEVICE
             "pretrained": True,  # USE EXISTING CHECKPOINT/PRETRAINED MODEL
             "max_epochs": 50,  # TOTAL EPOCHS TO RUN
@@ -139,7 +146,14 @@ class BundleTrainTask(TrainTask):
             else ["None", "mlflow"],
             "tracking_uri": settings.MONAI_LABEL_TRACKING_URI,
             "tracking_experiment_name": "",
+            "models": pytorch_models
         }
+
+        for k in self.const.key_loadable_configs():
+            loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config["loadable_params"]} if self.bundle_config.get(k) else {}
+            config_options.update(loadable_configs)
+
+        return config_options
 
     def _fetch_datalist(self, request, datastore: Datastore):
         datalist = datastore.datalist()
@@ -177,8 +191,9 @@ class BundleTrainTask(TrainTask):
         logger.info(f"Total Records for Validation: {len(val_datalist) if val_datalist else ''}")
         return train_datalist, val_datalist
 
-    def _load_checkpoint(self, output_dir, pretrained, train_handlers):
-        load_path = os.path.join(output_dir, self.const.model_pytorch()) if pretrained else None
+    def _load_checkpoint(self, model_pytorch, pretrained, train_handlers):
+
+        load_path = model_pytorch if pretrained else None
         if os.path.exists(load_path):
             logger.info(f"Add Checkpoint Loader for Path: {load_path}")
 
@@ -226,7 +241,9 @@ class BundleTrainTask(TrainTask):
         logger.info(f"(Experiment Management) Run Name: {tracking_run_name}")
 
         train_handlers = self.bundle_config.get(self.const.key_train_handlers(), [])
-        self._load_checkpoint(os.path.join(self.bundle_path, "models"), pretrained, train_handlers)
+
+        model_pytorch = os.path.join(self.bundle_path, "models", request.get("models", "model.pt"))
+        self._load_checkpoint(model_pytorch, pretrained, train_handlers)
 
         overrides = {
             self.const.key_bundle_root(): self.bundle_path,

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -259,7 +259,6 @@ class BundleTrainTask(TrainTask):
                 displayable_configs = self.bundle_config.get_parsed_content(k, instantiate=True)
                 overrides[k] = {c: request[c] for c in displayable_configs.keys()}
 
-                
         if tracking and tracking.lower() != "none":
             overrides[self.const.key_tracking()] = tracking
             if tracking_uri:

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -333,7 +333,6 @@ class BundleTrainTask(TrainTask):
         return {}
 
     def run_single_gpu(self, request, overrides):
-        print("Train here: {}".format(overrides))
         monai.bundle.run(
             "training",
             meta_file=self.bundle_metadata_path,

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -9,13 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import json
 import logging
 import os
 import subprocess
 import sys
 from typing import Dict, Optional, Sequence
-import glob
 
 import monai.bundle
 import torch
@@ -83,6 +83,7 @@ class BundleConstants:
     def key_loadable_configs(self) -> Sequence[str]:
         return ["loadable_params"]
 
+
 class BundleTrainTask(TrainTask):
     def __init__(
         self,
@@ -146,11 +147,13 @@ class BundleTrainTask(TrainTask):
             else ["None", "mlflow"],
             "tracking_uri": settings.MONAI_LABEL_TRACKING_URI,
             "tracking_experiment_name": "",
-            "models": pytorch_models
+            "models": pytorch_models,
         }
 
         for k in self.const.key_loadable_configs():
-            loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
+            loadable_configs = (
+                {p: self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
+            )
             config_options.update(loadable_configs)
 
         return config_options
@@ -192,7 +195,6 @@ class BundleTrainTask(TrainTask):
         return train_datalist, val_datalist
 
     def _load_checkpoint(self, model_pytorch, pretrained, train_handlers):
-
         load_path = model_pytorch if pretrained else None
         if os.path.exists(load_path):
             logger.info(f"Add Checkpoint Loader for Path: {load_path}")

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -130,7 +130,7 @@ class BundleTrainTask(TrainTask):
         return i
 
     def config(self):
-        # Add models and param optiom to infer option panel
+        # Add models and param optiom to train option panel
         pytorch_models = [os.path.basename(p) for p in glob.glob(os.path.join(self.bundle_path, "models", "*.pt"))]
         pytorch_models.sort(key=len)
 
@@ -150,7 +150,7 @@ class BundleTrainTask(TrainTask):
         }
 
         for k in self.const.key_loadable_configs():
-            loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config["loadable_params"]} if self.bundle_config.get(k) else {}
+            loadable_configs = {p:self.bundle_config[p] for p in self.bundle_config[k]} if self.bundle_config.get(k) else {}
             config_options.update(loadable_configs)
 
         return config_options

--- a/monailabel/utils/others/modelzoo_list.py
+++ b/monailabel/utils/others/modelzoo_list.py
@@ -31,4 +31,5 @@ MAINTAINED_BUNDLES = [
     "swin_unetr_btcv_segmentation",  # 3D transformer model for multi-organ segmentation. Added Oct 2022
     "wholeBrainSeg_Large_UNEST_segmentation",  # whole brain segmentation for T1 MRI brain images. Added Oct 2022
     "lung_nodule_ct_detection",  # The first lung nodule detection task can be used for MONAI Label. Added Dec 2022
+    "wholeBody_ct_segmentation", # The SegResNet trained TotalSegmentator dataset with 104 tissues. Added Feb 2023
 ]

--- a/monailabel/utils/others/modelzoo_list.py
+++ b/monailabel/utils/others/modelzoo_list.py
@@ -31,5 +31,5 @@ MAINTAINED_BUNDLES = [
     "swin_unetr_btcv_segmentation",  # 3D transformer model for multi-organ segmentation. Added Oct 2022
     "wholeBrainSeg_Large_UNEST_segmentation",  # whole brain segmentation for T1 MRI brain images. Added Oct 2022
     "lung_nodule_ct_detection",  # The first lung nodule detection task can be used for MONAI Label. Added Dec 2022
-    "wholeBody_ct_segmentation", # The SegResNet trained TotalSegmentator dataset with 104 tissues. Added Feb 2023
+    "wholeBody_ct_segmentation",  # The SegResNet trained TotalSegmentator dataset with 104 tissues. Added Feb 2023
 ]

--- a/sample-apps/monaibundle/README.md
+++ b/sample-apps/monaibundle/README.md
@@ -46,6 +46,7 @@ The Bundle App supports most labeling models in the Model Zoo, please see the ta
 | [wholeBrainSeg_UNEST_segmentation](https://github.com/Project-MONAI/model-zoo/tree/dev/models/wholeBrainSeg_Large_UNEST_segmentation) | UNesT | Whole Brain | MRI T1 |  A pre-trained for inference (3D) 133 whole brain structures segmentation |
 | [spleen_deepedit_annotation](https://github.com/Project-MONAI/model-zoo/tree/dev/models/spleen_deepedit_annotation) | DeepEdit | Spleen| CT | An interactive method for 3D spleen Segmentation |
 | [lung_nodule_ct_detection](https://github.com/Project-MONAI/model-zoo/tree/dev/models/lung_nodule_ct_detection) | RetinaNet | Lung Nodule| CT | The detection model for 3D CT images |
+| [wholeBody_ct_segmentation](https://github.com/Project-MONAI/model-zoo/tree/dev/models/wholeBody_ct_segmentation) | SegResNet | 104 body structures| CT | The segmentation model for 104 tissue from 3D CT images (TotalSegmentator Dataset) |
 
 Supported tasks update based on [Model-Zoo](https://github.com/Project-MONAI/model-zoo/tree/dev/models) release.
 


### PR DESCRIPTION
Some changes on supporting to load configs exposed to users (from bundle files). 

Works if a bundle provides more than one checkpoints for inference, or different configuration for training. 

Let's make it draft now, wait until totalSegmentator bundle is updated and merged. 

