### PR TITLE
ENH: Use non-deprecated Segment Editor API

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -358,7 +358,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # embedded segment editor
         self.ui.embeddedSegmentEditorWidget.setMRMLScene(slicer.mrmlScene)
         self.ui.embeddedSegmentEditorWidget.setSegmentationNodeSelectorVisible(False)
-        self.ui.embeddedSegmentEditorWidget.setMasterVolumeNodeSelectorVisible(False)
+        self.ui.embeddedSegmentEditorWidget.setSourceVolumeNodeSelectorVisible(False)
         self.ui.embeddedSegmentEditorWidget.setMRMLSegmentEditorNode(self.logic.get_segment_editor_node())
 
         # options section
@@ -1303,7 +1303,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Create Empty Segments for all labels for this node
         self.createSegmentNode()
         self.ui.embeddedSegmentEditorWidget.setSegmentationNode(self._segmentNode)
-        self.ui.embeddedSegmentEditorWidget.setMasterVolumeNode(self._volumeNode)
+        self.ui.embeddedSegmentEditorWidget.setSourceVolumeNode(self._volumeNode)
 
         self.createScribblesROINode()
         self.ui.scribblesPlaceWidget.setCurrentNode(self._scribblesROINode)
@@ -1330,7 +1330,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def getPermissionForImageDataUpload(self):
         return slicer.util.confirmOkCancelDisplay(
-            "Master volume - without any additional patient information -"
+            "Source volume - without any additional patient information -"
             " will be sent to remote data processing server: {}.\n\n"
             "Click 'OK' to proceed with the segmentation.\n"
             "Click 'Cancel' to not upload any data and cancel segmentation.\n".format(self.serverUrl()),
@@ -1740,7 +1740,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 addedSegmentIds = [segmentation.GetNthSegmentID(existingCount + i) for i in range(addedCount)]
 
                 self.ui.embeddedSegmentEditorWidget.setSegmentationNode(segmentationNode)
-                self.ui.embeddedSegmentEditorWidget.setMasterVolumeNode(self._volumeNode)
+                self.ui.embeddedSegmentEditorWidget.setSourceVolumeNode(self._volumeNode)
 
                 for i, segmentId in enumerate(addedSegmentIds):
                     label = labels[i] if i < len(labels) else f"unknown {i}"
@@ -1856,7 +1856,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # change segmentation display properties to "see through" the scribbles
         # further explanation at:
-        # https://apidocs.slicer.org/master/classvtkMRMLSegmentationDisplayNode.html
+        # https://apidocs.slicer.org/main/classvtkMRMLSegmentationDisplayNode.html
         segmentationDisplayNode = self._segmentNode.GetDisplayNode()
 
         # background

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -77,7 +77,7 @@
      <item row="2" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Master Volume:</string>
+        <string>Source Volume:</string>
        </property>
       </widget>
      </item>
@@ -321,7 +321,7 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="qMRMLSegmentEditorWidget" name="embeddedSegmentEditorWidget">
-        <property name="autoShowMasterVolumeNode">
+        <property name="autoShowSourceVolumeNode">
          <bool>true</bool>
         </property>
         <property name="maximumNumberOfUndoStates">

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
@@ -29,7 +29,7 @@ from slicer.util import VTKObservationMixin
 
 class MONAILabelReviewer(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
@@ -49,7 +49,7 @@ Developed by rAiDiance, and  funded by Berlin Institute of Health (BIH).
 
 class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent=None):
@@ -1294,7 +1294,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
 
     # Sub Section: Display version selection option
     def activateSegmentatorEditor(self, activated=False):
-        self.segmentEditorWidget.setMasterVolumeNodeSelectorVisible(activated)
+        self.segmentEditorWidget.setSourceVolumeNodeSelectorVisible(activated)
         self.segmentEditorWidget.setSegmentationNodeSelectorVisible(activated)
         self.segmentEditorWidget.setSwitchToSegmentationsButtonVisible(activated)
         self.segmentEditorWidget.unorderedEffectsVisible = activated
@@ -1387,9 +1387,9 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
 
     def displayLabelOfSegmentation(self):
         self.selectParameterNode()
-        self.getDefaultMasterVolumeNodeID()
+        self.getDefaultSourceVolumeNodeID()
         self.segmentEditorWidget.SegmentationNodeComboBox.setCurrentNodeIndex(0)
-        self.segmentEditorWidget.MasterVolumeNodeComboBox.setCurrentNodeIndex(0)
+        self.segmentEditorWidget.SourceVolumeNodeComboBox.setCurrentNodeIndex(0)
 
     def selectParameterNode(self):
         # Select parameter set node if one is found in the scene, and create one otherwise
@@ -1402,7 +1402,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
             segmentEditorNode = slicer.mrmlScene.AddNode(segmentEditorNode)
         self.segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
 
-    def getDefaultMasterVolumeNodeID(self):
+    def getDefaultSourceVolumeNodeID(self):
         layoutManager = slicer.app.layoutManager()
         firstForegroundVolumeID = None
         # Use first background volume node in any of the displayed layouts.
@@ -1533,7 +1533,7 @@ class MONAILabelReviewerLogic(ScriptedLoadableModuleLogic):
     this class and make use of the functionality without
     requiring an instance of the Widget.
     Uses ScriptedLoadableModuleLogic base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self):
@@ -1740,7 +1740,7 @@ class MONAILabelReviewerTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def setUp(self):


### PR DESCRIPTION
Previous uses of "Master Volume" were replaced with "Source Volume" in an effort to use more inclusive language. See https://tools.ietf.org/id/draft-knodel-terminology-09.html#name-master-slave. These deprecation warnings in the Slicer API began with the Slicer 5.2 release.