### PR TITLE
Fix MONAILabelReviewer

### DIFF
--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
@@ -1240,7 +1240,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
                                 which is required for rest request to monai server
                                 in order to get dicom and segmenation (.nrrd).
         """
-        #slicer.mrmlScene.Clear()
+        # slicer.mrmlScene.Clear()
         self.clearInformationFields()
 
         if tag == "":
@@ -1710,9 +1710,7 @@ class MONAILabelReviewerLogic(ScriptedLoadableModuleLogic):
 
     def requestDicomImage(self, image_id: str, image_name: str, node_name: str):
         download_uri = self.imageDataController.getDicomDownloadUri(image_id)
-        SampleData.SampleDataLogic().downloadFromURL(
-            nodeNames=node_name, fileNames=image_name, uris=download_uri
-        )
+        SampleData.SampleDataLogic().downloadFromURL(nodeNames=node_name, fileNames=image_name, uris=download_uri)
 
     def setTempFolderDir(self):
         """

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
@@ -1294,7 +1294,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
 
     # Sub Section: Display version selection option
     def activateSegmentatorEditor(self, activated=False):
-        self.segmentEditorWidget.setMasterVolumeNodeSelectorVisible(activated)
+        self.segmentEditorWidget.setSourceVolumeNodeSelectorVisible(activated)
         self.segmentEditorWidget.setSegmentationNodeSelectorVisible(activated)
         self.segmentEditorWidget.setSwitchToSegmentationsButtonVisible(activated)
         self.segmentEditorWidget.unorderedEffectsVisible = activated

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
@@ -1240,7 +1240,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
                                 which is required for rest request to monai server
                                 in order to get dicom and segmenation (.nrrd).
         """
-        slicer.mrmlScene.Clear()
+        #slicer.mrmlScene.Clear()
         self.clearInformationFields()
 
         if tag == "":
@@ -1665,14 +1665,13 @@ class MONAILabelReviewerLogic(ScriptedLoadableModuleLogic):
         image_name = imageData.getFileName()
         image_id = imageData.getName()
         node_name = imageData.getNodeName()
-        checksum = imageData.getCheckSum()
         logging.info(
-            "{}: Request Data  image_name='{}', node_name='{}', image_id='{}', checksum='{}'".format(
-                self.getCurrentTime(), image_name, node_name, image_id, checksum
+            "{}: Request Data  image_name='{}', node_name='{}', image_id='{}'".format(
+                self.getCurrentTime(), image_name, node_name, image_id
             )
         )
 
-        self.requestDicomImage(image_id, image_name, node_name, checksum)
+        self.requestDicomImage(image_id, image_name, node_name)
         self.setTempFolderDir()
 
         # Request segmentation
@@ -1709,12 +1708,11 @@ class MONAILabelReviewerLogic(ScriptedLoadableModuleLogic):
         """
         segmentation = slicer.util.loadSegmentation(destination)
 
-    def requestDicomImage(self, image_id: str, image_name: str, node_name: str, checksum: str):
+    def requestDicomImage(self, image_id: str, image_name: str, node_name: str):
         download_uri = self.imageDataController.getDicomDownloadUri(image_id)
-        sampleDataLogic = SampleData.SampleDataLogic()
-        _volumeNode = sampleDataLogic.downloadFromURL(
-            nodeNames=node_name, fileNames=image_name, uris=download_uri, checksums=checksum
-        )[0]
+        SampleData.SampleDataLogic().downloadFromURL(
+            nodeNames=node_name, fileNames=image_name, uris=download_uri
+        )
 
     def setTempFolderDir(self):
         """

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/DataStoreKeys.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/DataStoreKeys.py
@@ -33,7 +33,6 @@ class DataStoreKeys:
         self.FILENAME = ["image", "info", "name"]
         self.NODE_NAME = ["image", "info", "name"]
 
-        self.CHECKSUM = ["image", "info", "checksum"]
         self.TIMESTAMP = ["image", "info", "ts"]
         self.TIMESTAMP_ANNOTATE = ["image", "info", "strategy", "annotate", "ts"]
         self.TIMESTAMP_RANDOM = ["image", "info", "strategy", "Random", "ts"]

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/ImageData.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/ImageData.py
@@ -27,11 +27,10 @@ to persist the data in datastore_v2.json file.
 
 
 class ImageData:
-    def __init__(self, name, fileName, nodeName, checkSum, segmented, timeStamp, comment=""):
+    def __init__(self, name, fileName, nodeName, segmented, timeStamp, comment=""):
         self.name: str = name  # equals imageId
         self.fileName: str = fileName
         self.nodeName: str = nodeName
-        self.checkSum: str = checkSum
         self.segmented: bool = segmented
         self.timeStamp: int = timeStamp
         self.comment: str = comment
@@ -91,9 +90,6 @@ class ImageData:
 
     def getNodeName(self) -> str:
         return self.nodeName
-
-    def getCheckSum(self) -> str:
-        return self.checkSum
 
     def getsegmentationMetaDict(self) -> dict:
         return self.segmentationMetaDict
@@ -411,7 +407,6 @@ class ImageData:
         print("name: ", self.name)
         print("fileName: ", self.fileName)
         print("nodeName: ", self.nodeName)
-        print("checksum: ", self.checkSum)
         print("isSegmented: ", self.segmented)
         print("getTimeStamp: ", self.getTimeOfAnnotation())
         print("=== Version labels ====")

--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/JsonParser.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewerLib/JsonParser.py
@@ -48,9 +48,6 @@ class JsonParser:
     def getNodeName(self, obj: dict) -> str:
         return self.getValueByKey(self.dataStoreKeys.NODE_NAME, obj)
 
-    def getCheckSum(self, obj: dict) -> str:
-        return self.getValueByKey(self.dataStoreKeys.CHECKSUM, obj)
-
     def getTimeStamp(self, obj: dict) -> int:
         if self.hasKeyAnnotate(obj):
             return self.getValueByKey(self.dataStoreKeys.TIMESTAMP_ANNOTATE, obj)
@@ -211,7 +208,6 @@ class JsonParser:
             name=key,
             fileName=self.getFileName(value),
             nodeName=self.getNodeName(value),
-            checkSum=self.getCheckSum(value),
             segmented=self.isSegmented(value),
             timeStamp=self.getTimeStamp(value),
         )


### PR DESCRIPTION
The Slicer plugin MONAILabelReviewer crashes and is not working anymore. This PR fixes #1300.

- removes image-info-checksum related code (caused Slicer to crash)
- removes deprecation warnings