### PR TITLE
BUG: Fix MONAILabelReviewer crash at Slicer scene close

### DIFF
--- a/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
+++ b/plugins/slicer/MONAILabelReviewer/MONAILabelReviewer.py
@@ -1383,6 +1383,7 @@ class MONAILabelReviewerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
     # Section: Display label
     def addSegmentator(self):
         self.segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        self.selectParameterNode()
         self.segmentEditorWidget.setEffectNameOrder([])
 
     def displayLabelOfSegmentation(self):


### PR DESCRIPTION
When the Slicer scene was closed without having a parameter node set in the Segment Editor widget (using setMRMLSegmentEditorNode), the application crashed (due to a missing null-pointer check). The null-pointer check was added for latest Slicer-5.3 version in https://github.com/Slicer/Slicer/commit/9506e42834364ad528f5e26c0150ca25e4c44999.

To fix the crash in all other Slicer versions, this commit sets the parameter node in the Segment Editor widget right after the scene is set in it. It is appropriate to do this anyway, as it ensures that all other parameters that are set in the Segment Editor widget can be stored in the parameter node.

see #1300