### PR TITLE
copy log config with `copyfile` to mitigate permissions issues

### DIFF
--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -101,7 +101,7 @@ def init_log_config(log_config, app_dir, log_file, root_level=None):
         os.makedirs(log_dir, exist_ok=True)
 
         # if not os.path.exists(log_config):
-        shutil.copy(default_config, log_config)
+        shutil.copyfile(default_config, log_config)
         with open(log_config) as f:
             c = f.read()
 


### PR DESCRIPTION
I wanted to set up monai somewhere that multiple users with access to the server could start it. Based on [this thread](https://unix.stackexchange.com/questions/128665/who-should-own-files-shared-by-a-group-and-where-should-they-go) I ended up creating a `/home/monai` directory owned by `root:monai`. 

However, I hit an error when I ran the server, related to copying the log file. I think this page summarises the error nicely: https://stackoverflow.com/questions/11835833/why-would-shutil-copy-raise-a-permission-exception-when-cp-doesnt

Indeed, changing this line from `shutil.copy` to `shutil.copyfile` resolved the error.

This might be an X/Y problem, as I'm sure there are many more things which could/should be changed for monai to become a multi-user platform, but in the meantime it seems like an easy fix with no downsides.