### PR TITLE
Exclude npm and gradle detectors

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -82,7 +82,7 @@ jobs:
       #       echo detect.maven.included.scopes=compile >> application.properties
       - name: Setup blackduck properties
         run: |
-             echo detect.excluded.detector.types=PIP >> application.properties
+             echo detect.excluded.detector.types=PIP,NPM,GRADLE >> application.properties
 
       - name: Run blossom action
         uses: NVIDIA/blossom-action@main


### PR DESCRIPTION
fix #1320 

exlucde npm and gradle detectors in blackduck