### PR TITLE
Update Endo plugin of monai 1.2rc2 support

### DIFF
--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -180,18 +180,20 @@ class Main:
     def _get_installed_dir(self, prefix, name):
         project_root_absolute = pathlib.Path(__file__).parent.parent.resolve()
         # add searched paths to include variant python installation options
-        # Specify --prefix for customized download path 
+        # Specify --prefix for customized download path
         installed_dirs = [
             os.path.join(project_root_absolute, name),
             os.path.join(prefix, "monailabel", name) if prefix else None,
             os.path.join(sys.prefix, "monailabel", name),
             os.path.join(sys.prefix, "local", "monailabel", name),
-            os.path.join(pathlib.Path.home(), ".local", "monailabel", name)
+            os.path.join(pathlib.Path.home(), ".local", "monailabel", name),
         ]
         for d in installed_dirs:
             if d and os.path.exists(d):
                 return d
-        raise ValueError(f"Cannot find MONAI Label installed: {name} installed directory. Add '--prefix' of installed path.")
+        raise ValueError(
+            f"Cannot find MONAI Label installed: {name} installed directory. Add '--prefix' of installed path."
+        )
 
     def _action_xyz(self, args, name, title, exclude, ignore):
         xyz_dir = self._get_installed_dir(args.prefix, name)

--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -179,8 +179,6 @@ class Main:
 
     def _get_installed_dir(self, prefix, name):
         project_root_absolute = pathlib.Path(__file__).parent.parent.resolve()
-        d = os.path.join(project_root_absolute, name)
-
         # add searched paths to include variant python installation options
         # Specify --prefix for customized download path 
         installed_dirs = [

--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -191,7 +191,7 @@ class Main:
         for d in installed_dirs:
             if d and os.path.exists(d):
                 return d
-        raise ValueError(f"Cannot find MONAI Label App: {name} installed directory. Add '--prefix' of installed path.")
+        raise ValueError(f"Cannot find MONAI Label installed: {name} installed directory. Add '--prefix' of installed path.")
 
     def _action_xyz(self, args, name, title, exclude, ignore):
         xyz_dir = self._get_installed_dir(args.prefix, name)

--- a/monailabel/main.py
+++ b/monailabel/main.py
@@ -180,14 +180,20 @@ class Main:
     def _get_installed_dir(self, prefix, name):
         project_root_absolute = pathlib.Path(__file__).parent.parent.resolve()
         d = os.path.join(project_root_absolute, name)
-        if not os.path.exists(d):
-            if prefix:
-                d = os.path.join(prefix, "monailabel", name)
-            else:
-                d = os.path.join(sys.prefix, "monailabel", name)
-                if not os.path.exists(d):
-                    d = os.path.join(pathlib.Path.home(), ".local", "monailabel", name)
-        return d
+
+        # add searched paths to include variant python installation options
+        # Specify --prefix for customized download path 
+        installed_dirs = [
+            os.path.join(project_root_absolute, name),
+            os.path.join(prefix, "monailabel", name) if prefix else None,
+            os.path.join(sys.prefix, "monailabel", name),
+            os.path.join(sys.prefix, "local", "monailabel", name),
+            os.path.join(pathlib.Path.home(), ".local", "monailabel", name)
+        ]
+        for d in installed_dirs:
+            if d and os.path.exists(d):
+                return d
+        raise ValueError(f"Cannot find MONAI Label App: {name} installed directory. Add '--prefix' of installed path.")
 
     def _action_xyz(self, args, name, title, exclude, ignore):
         xyz_dir = self._get_installed_dir(args.prefix, name)

--- a/plugins/cvat/endoscopy/deepedit.yaml
+++ b/plugins/cvat/endoscopy/deepedit.yaml
@@ -34,11 +34,11 @@ spec:
     directives:
       preCopy:
         - kind: ENV
-          value: MONAI_LABEL_APP_DIR=/opt/conda/monailabel/sample-apps/endoscopy
+          value: MONAI_LABEL_APP_DIR=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_LABEL_MODELS=deepedit
         - kind: ENV
-          value: PYTHONPATH=/opt/conda/monailabel/sample-apps/endoscopy
+          value: PYTHONPATH=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_PRETRAINED_PATH=https://github.com/Project-MONAI/MONAILabel/releases/download/data
         - kind: ENV

--- a/plugins/cvat/endoscopy/inbody.yaml
+++ b/plugins/cvat/endoscopy/inbody.yaml
@@ -35,11 +35,11 @@ spec:
     directives:
       preCopy:
         - kind: ENV
-          value: MONAI_LABEL_APP_DIR=/opt/conda/monailabel/sample-apps/endoscopy
+          value: MONAI_LABEL_APP_DIR=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_LABEL_MODELS=inbody
         - kind: ENV
-          value: PYTHONPATH=/opt/conda/monailabel/sample-apps/endoscopy
+          value: PYTHONPATH=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_PRETRAINED_PATH=https://github.com/Project-MONAI/MONAILabel/releases/download/data
 

--- a/plugins/cvat/endoscopy/tooltracking.yaml
+++ b/plugins/cvat/endoscopy/tooltracking.yaml
@@ -34,11 +34,11 @@ spec:
     directives:
       preCopy:
         - kind: ENV
-          value: MONAI_LABEL_APP_DIR=/opt/conda/monailabel/sample-apps/endoscopy
+          value: MONAI_LABEL_APP_DIR=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_LABEL_MODELS=tooltracking
         - kind: ENV
-          value: PYTHONPATH=/opt/conda/monailabel/sample-apps/endoscopy
+          value: PYTHONPATH=/usr/local/monailabel/sample-apps/endoscopy
         - kind: ENV
           value: MONAI_PRETRAINED_PATH=https://github.com/Project-MONAI/MONAILabel/releases/download/data
 


### PR DESCRIPTION
This fixes the endoscopy app in the latest Docker, which caused by the change of base Docker. 
 
`_get_installed_dir` reformats, add ValueError if installed dir is not found. Add notice of "--prefix" if not found by default.