### PR TITLE
Support monai 1.2.0rc3 and bundle API fix

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # please run `./runtests.sh --clean && DOCKER_BUILDKIT=1 docker build -t projectmonai/monailabel:latest .`
 # to use different version of MONAI pass `--build-arg MONAI_IMAGE=...`
 
-ARG MONAI_IMAGE=projectmonai/monai:1.2.0rc2
+ARG MONAI_IMAGE=projectmonai/monai:1.2.0rc3
 
 FROM ${MONAI_IMAGE} as build
 LABEL maintainer="monai.contact@gmail.com"

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -337,7 +337,7 @@ class BundleTrainTask(TrainTask):
         logger.info("Training Finished....")
         return {}
 
-    def run_single_gpu(self, request, overrides):
+    def run_single_gpu(self, request, overrides):        
         run_id = request.get("run_id", "")
         monai.bundle.run(
             run_id=run_id,

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -144,6 +144,7 @@ class BundleTrainTask(TrainTask):
             else ["None", "mlflow"],
             "tracking_uri": settings.MONAI_LABEL_TRACKING_URI,
             "tracking_experiment_name": "",
+            "run_id": "", # bundle run id, if different from default
             "model_filename": pytorch_models,
         }
 
@@ -212,6 +213,8 @@ class BundleTrainTask(TrainTask):
         max_epochs = request.get("max_epochs", 50)
         pretrained = request.get("pretrained", True)
         multi_gpu = request.get("multi_gpu", True)
+        run_id = request.get("run_id", "")
+
         multi_gpu = multi_gpu if torch.cuda.device_count() > 1 else False
 
         gpus = request.get("gpus", "all")
@@ -308,7 +311,7 @@ class BundleTrainTask(TrainTask):
                 "-m",
                 "monai.bundle",
                 "run",
-                "training",
+                run_id, #run_id, user can pass the arg
                 "--meta_file",
                 self.bundle_metadata_path,
                 "--config_file",
@@ -335,8 +338,11 @@ class BundleTrainTask(TrainTask):
         return {}
 
     def run_single_gpu(self, request, overrides):
+        run_id = request.get("run_id", "")
         monai.bundle.run(
-            "training",
+            run_id=run_id,
+            init_id=None,
+            final_id=None,            
             meta_file=self.bundle_metadata_path,
             config_file=self.bundle_config_path,
             **overrides,

--- a/monailabel/tasks/train/bundle.py
+++ b/monailabel/tasks/train/bundle.py
@@ -144,7 +144,7 @@ class BundleTrainTask(TrainTask):
             else ["None", "mlflow"],
             "tracking_uri": settings.MONAI_LABEL_TRACKING_URI,
             "tracking_experiment_name": "",
-            "run_id": "", # bundle run id, if different from default
+            "run_id": "",  # bundle run id, if different from default
             "model_filename": pytorch_models,
         }
 
@@ -311,7 +311,7 @@ class BundleTrainTask(TrainTask):
                 "-m",
                 "monai.bundle",
                 "run",
-                run_id, #run_id, user can pass the arg
+                run_id,  # run_id, user can pass the arg
                 "--meta_file",
                 self.bundle_metadata_path,
                 "--config_file",
@@ -337,12 +337,12 @@ class BundleTrainTask(TrainTask):
         logger.info("Training Finished....")
         return {}
 
-    def run_single_gpu(self, request, overrides):        
+    def run_single_gpu(self, request, overrides):
         run_id = request.get("run_id", "")
         monai.bundle.run(
             run_id=run_id,
             init_id=None,
-            final_id=None,            
+            final_id=None,
             meta_file=self.bundle_metadata_path,
             config_file=self.bundle_config_path,
             **overrides,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 
 torch>=1.7
 itk>=5.3rc4.post3; python_version == '3.10'
-monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire, mlflow]>=1.2.0rc2
+monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire, mlflow]>=1.2.0rc3
 uvicorn==0.17.6
 pydantic>=1.8.2
 python-dotenv==0.20.0

--- a/sample-apps/monaibundle/README.md
+++ b/sample-apps/monaibundle/README.md
@@ -86,6 +86,15 @@ monailabel start_server --app workspace/monaibundle --studies workspace/images -
 monailabel start_server --app workspace/monaibundle --studies workspace/images --conf models spleen_ct_segmentation --conf skip_trainers true
 ```
 
+**Specify bundle version** (Optional)
+Above command will download the latest bundles from Model-Zoo by default. If a specific or older bundle version is used, users can add version `_v` followed by the bundle name. Example:
+
+```bash
+monailabel start_server --app workspace/monaibundle --studies workspace/images --conf models spleen_ct_segmentation_v0.3.7
+```
+Note: bundles in Model-Zoo are continuously updated, we recommend users use the latest MONAI Label version for the best bundle compatibility experience.
+
+
 ### Epistemic Scoring for monaibundle app
 
 The monaibundle app supports epistemic scoring using bundles models. The monaibundle consumes **epistemic_model** as config parameter.

--- a/sample-apps/monaibundle/README.md
+++ b/sample-apps/monaibundle/README.md
@@ -92,7 +92,7 @@ Above command will download the latest bundles from Model-Zoo by default. If a s
 ```bash
 monailabel start_server --app workspace/monaibundle --studies workspace/images --conf models spleen_ct_segmentation_v0.3.7
 ```
-Note: bundles in Model-Zoo are continuously updated, old bundles may contain deprecated API, we recommend using the latest realeased MONAI Label and bundle for the best 
+Note: bundles in Model-Zoo are continuously updated, old bundles may contain deprecated API, we recommend using the latest realeased MONAI Label and bundle for the best
  experience.
 
 ### Epistemic Scoring for monaibundle app

--- a/sample-apps/monaibundle/README.md
+++ b/sample-apps/monaibundle/README.md
@@ -92,8 +92,8 @@ Above command will download the latest bundles from Model-Zoo by default. If a s
 ```bash
 monailabel start_server --app workspace/monaibundle --studies workspace/images --conf models spleen_ct_segmentation_v0.3.7
 ```
-Note: bundles in Model-Zoo are continuously updated, we recommend users use the latest MONAI Label version for the best bundle compatibility experience.
-
+Note: bundles in Model-Zoo are continuously updated, old bundles may contain deprecated API, we recommend using the latest realeased MONAI Label and bundle for the best 
+ experience.
 
 ### Epistemic Scoring for monaibundle app
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ setup_requires =
 install_requires =
     torch>=1.7
     itk>=5.3rc4.post3; python_version == '3.10'
-    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire, mlflow]>=1.2.0rc2
+    monai[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, openslide, fire, mlflow]>=1.2.0rc3
     uvicorn==0.17.6
     pydantic>=1.8.2
     python-dotenv==0.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ project_urls =
     Source Code=https://github.com/Project-MONAI/MONAILabel
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 # for compiling and develop setup only
 # no need to specify the versions so that we could
 # compile for multiple targeted versions.

--- a/tests/unit/endpoints/test_train.py
+++ b/tests/unit/endpoints/test_train.py
@@ -112,7 +112,7 @@ class TestDetectionBundleTrainTask(BasicDetectionBundleTestSuite):
             "val_split": 0.5,
             "multi_gpu": False,
             "dataset": "CacheDataset",
-            "run_id": "training"
+            "run_id": "training",
         }
         response = self.client.post("/train/?run_sync=True", json=params)
         assert response.status_code == 200

--- a/tests/unit/endpoints/test_train.py
+++ b/tests/unit/endpoints/test_train.py
@@ -112,6 +112,7 @@ class TestDetectionBundleTrainTask(BasicDetectionBundleTestSuite):
             "val_split": 0.5,
             "multi_gpu": False,
             "dataset": "CacheDataset",
+            "run_id": "training"
         }
         response = self.client.post("/train/?run_sync=True", json=params)
         assert response.status_code == 200


### PR DESCRIPTION
Support monai 1.2.0rc3

Support new bundle APi, support new bundles, and fix compatibility to old bundles.

Note, if users use MONAI Label <=0.7.0rc3, they can't use new bundles, e.g., spleen_ct_segmentation_v0.4.0, they need to download the old version of the bundle as well. 

Compatibility is available of MONAI Label (0.7.0 xx) to all new and old bundles versions. 