### PR TITLE
Improve filtering for download of  labeled data in DICOMWeb datastore

### DIFF
--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -245,7 +245,6 @@ class DICOMWebDatastore(LocalDatastore):
                         str(seg["SeriesInstanceUID"].value)
                     )
                 )
-            )
 
         invalid = set(super().get_labeled_images()) - {image_label["image"] for image_label in image_labels}
         logger.info(f"Invalid Labels: {invalid}")

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -222,17 +222,29 @@ class DICOMWebDatastore(LocalDatastore):
                 str(seg["StudyInstanceUID"].value), str(seg["SeriesInstanceUID"].value)
             )
             seg_meta = Dataset.from_json(meta[0])
-            if not seg_meta.get("ReferencedSeriesSequence"):
-                logger.warning(
-                    f"Label Ignored:: ReferencedSeriesSequence is NOT found: {str(seg['SeriesInstanceUID'].value)}"
+            if seg_meta.get("ReferencedSeriesSequence"):
+                referenced_series_instance_uid = str(
+                    seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value
                 )
-                continue
-
-            image_labels.append(
-                {
-                    "image": str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value),
-                    "label": str(seg["SeriesInstanceUID"].value),
-                }
+                if referenced_series_instance_uid in self.list_images():
+                    image_labels.append(
+                        {
+                            "image": str(seg_meta["ReferencedSeriesSequence"].value[0]["SeriesInstanceUID"].value),
+                            "label": str(seg["SeriesInstanceUID"].value),
+                        }
+                    )
+                else:
+                    logger.warning(
+                        "Label Ignored:: ReferencedSeriesSequence is NOT in filtered image list: {}".format(
+                            str(seg["SeriesInstanceUID"].value)
+                        )
+                    )
+            else:
+                logger.warning(
+                    "Label Ignored:: ReferencedSeriesSequence is NOT found: {}".format(
+                        str(seg["SeriesInstanceUID"].value)
+                    )
+                )
             )
 
         invalid = set(super().get_labeled_images()) - {image_label["image"] for image_label in image_labels}


### PR DESCRIPTION
When having a large DICOMWeb datastore with lots of different DICOMSEGs from lots of different reference DICOM series `_download_labeled_data()` of `DICOMWebDatastore` downloads all DICOMSEGs available regardless of the filtered image list (`list_images()`) defined by `settings.MONAI_LABEL_DICOMWEB_SEARCH_FILTER`. This also can cause issues of `datalist()`.

The current implementation of `_download_labeled_data()` lacks one important check to sort out irrelevant DICOMSEGs. This PR adds one more check in order to download only DICOMSEGs that match  `settings.MONAI_LABEL_DICOMWEB_SEARCH_FILTER`.

The additional check is mainly a copy from `get_labeled_images()`:
https://github.com/Project-MONAI/MONAILabel/blob/943d545efdc6e3d6a50f959b1d7dd1b19d80e372/monailabel/datastore/dicom.py#L150-L157