### PR TITLE
[Slicer] Fixed the "Background" label in the SmartEdit/Deepgrow section being hidden

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -664,6 +664,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.freezeUpdateCheckBox.show()
             self.ui.dgLabelForeground.setText("Landmarks:")
         else:
+            self.ui.dgLabelBackground.show()
             self.ui.dgNegativeControlPointPlacementWidget.show()
             self.ui.freezeUpdateCheckBox.hide()
             self.ui.dgLabelForeground.setText("Foreground:")


### PR DESCRIPTION
Fixed the "Background" label in the SmartEdit/Deepgrow section being hidden when switching to the deepedit model and then back to the deepgrow model.

Before:
![image](https://github.com/Project-MONAI/MONAILabel/assets/32849887/98b56404-05cb-4a35-a454-e55910183eb5)
After:
![vncviewer_dXDLgEq11s](https://github.com/Project-MONAI/MONAILabel/assets/32849887/07cddab1-4813-4960-aa0f-6a8c1025edb8)