### PR TITLE
Fixed a small typo in the Slicer Module

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -190,7 +190,7 @@ class _ui_MONAILabelSettingsPanel:
         if slicer.util.settingsValue("MONAILabel/allowOverlappingSegments", True, converter=slicer.util.toBool):
             if slicer.util.settingsValue("MONAILabel/fileExtension", None) != ".seg.nrrd":
                 slicer.util.warningDisplay(
-                    "Overlapping segmentations are only availabel with the '.seg.nrrd' file extension! "
+                    "Overlapping segmentations are only available with the '.seg.nrrd' file extension! "
                     + "Consider changing MONAILabel file extension."
                 )
 


### PR DESCRIPTION
In the MONAILabel Slicer Module, there's a small typo in the warning that gets displayed in the onUpdateAllowOverlap function. That has been fixed.