### PR TITLE
Fix md5 hashing with FIPS mode

### DIFF
--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -9,12 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import logging
 import os
 import pathlib
 import shutil
-import sys
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import requests
@@ -27,6 +25,7 @@ from monailabel.datastore.local import LocalDatastore
 from monailabel.datastore.utils.convert import binary_to_image, dicom_to_nifti, nifti_to_dicom_seg
 from monailabel.datastore.utils.dicom import dicom_web_download_series, dicom_web_upload_dcm
 from monailabel.interfaces.datastore import DefaultLabelTag
+from monailabel.utils.others.generic import md5_digest
 
 logger = logging.getLogger(__name__)
 
@@ -54,11 +53,7 @@ class DICOMWebDatastore(LocalDatastore):
         self._fetch_by_frame = fetch_by_frame
         self._convert_to_nifti = convert_to_nifti
 
-        uri_hash = ""
-        if sys.version_info.minor < 9:
-            uri_hash = hashlib.md5(self._client.base_url.encode("utf-8")).hexdigest()
-        else:
-            uri_hash = hashlib.md5(self._client.base_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        uri_hash = md5_digest(self._client.base_url)
         datastore_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -12,6 +12,7 @@
 import hashlib
 import logging
 import os
+import sys
 import pathlib
 import shutil
 from typing import Any, Dict, Iterator, List, Optional, Tuple
@@ -53,7 +54,11 @@ class DICOMWebDatastore(LocalDatastore):
         self._fetch_by_frame = fetch_by_frame
         self._convert_to_nifti = convert_to_nifti
 
-        uri_hash = hashlib.md5(self._client.base_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        uri_hash = ""
+        if sys.version_info.minor < 9:
+            uri_hash = hashlib.md5(self._client.base_url.encode("utf-8")).hexdigest()
+        else:
+            uri_hash = hashlib.md5(self._client.base_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         datastore_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -12,9 +12,9 @@
 import hashlib
 import logging
 import os
-import sys
 import pathlib
 import shutil
+import sys
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import requests

--- a/monailabel/datastore/dicom.py
+++ b/monailabel/datastore/dicom.py
@@ -53,7 +53,7 @@ class DICOMWebDatastore(LocalDatastore):
         self._fetch_by_frame = fetch_by_frame
         self._convert_to_nifti = convert_to_nifti
 
-        uri_hash = hashlib.md5(self._client.base_url.encode("utf-8")).hexdigest()
+        uri_hash = hashlib.md5(self._client.base_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         datastore_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/dsa.py
+++ b/monailabel/datastore/dsa.py
@@ -12,6 +12,7 @@
 import hashlib
 import logging
 import os
+import sys
 import pathlib
 from io import BytesIO
 from pathlib import Path
@@ -35,7 +36,11 @@ class DSADatastore(Datastore):
         self.annotation_groups = [a.lower() if a else a for a in annotation_groups] if annotation_groups else []
         self.asset_store_path = asset_store_path
 
-        uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        uri_hash = ""
+        if sys.version_info.minor < 9:
+            uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
+        else:
+            uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         self.cache_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/dsa.py
+++ b/monailabel/datastore/dsa.py
@@ -12,8 +12,8 @@
 import hashlib
 import logging
 import os
-import sys
 import pathlib
+import sys
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/monailabel/datastore/dsa.py
+++ b/monailabel/datastore/dsa.py
@@ -9,11 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import logging
 import os
 import pathlib
-import sys
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -23,6 +21,7 @@ import numpy as np
 from PIL import Image
 
 from monailabel.interfaces.datastore import Datastore, DefaultLabelTag
+from monailabel.utils.others.generic import md5_digest
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +35,7 @@ class DSADatastore(Datastore):
         self.annotation_groups = [a.lower() if a else a for a in annotation_groups] if annotation_groups else []
         self.asset_store_path = asset_store_path
 
-        uri_hash = ""
-        if sys.version_info.minor < 9:
-            uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
-        else:
-            uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        uri_hash = md5_digest(api_url)
         self.cache_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/dsa.py
+++ b/monailabel/datastore/dsa.py
@@ -35,7 +35,7 @@ class DSADatastore(Datastore):
         self.annotation_groups = [a.lower() if a else a for a in annotation_groups] if annotation_groups else []
         self.asset_store_path = asset_store_path
 
-        uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
+        uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         self.cache_path = (
             os.path.join(cache_path, uri_hash)
             if cache_path

--- a/monailabel/datastore/utils/dicom.py
+++ b/monailabel/datastore/utils/dicom.py
@@ -11,27 +11,20 @@
 
 import logging
 import os
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
-from hashlib import md5
 
 from dicomweb_client import DICOMwebClient
 from pydicom.dataset import Dataset
 from pydicom.filereader import dcmread
 
-from monailabel.utils.others.generic import run_command
+from monailabel.utils.others.generic import run_command, md5_digest
 
 logger = logging.getLogger(__name__)
 
 
 def generate_key(patient_id: str, study_id: str, series_id: str):
-    key = ""
-    if sys.version_info.minor < 9:
-        key = md5(f"{patient_id}+{study_id}+{series_id}".encode()).hexdigest()
-    else:
-        key = md5(f"{patient_id}+{study_id}+{series_id}".encode(), usedforsecurity=False).hexdigest()
-    return key
+    return md5_digest(f"{patient_id}+{study_id}+{series_id}")
 
 
 def get_scu(query, output_dir, query_level="SERIES", host="127.0.0.1", port="4242", aet="MONAILABEL"):

--- a/monailabel/datastore/utils/dicom.py
+++ b/monailabel/datastore/utils/dicom.py
@@ -11,6 +11,7 @@
 
 import logging
 import os
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import md5
@@ -25,7 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 def generate_key(patient_id: str, study_id: str, series_id: str):
-    return md5(f"{patient_id}+{study_id}+{series_id}".encode(), usedforsecurity=False).hexdigest()
+    key = ""
+    if sys.version_info.minor < 9:
+        key = md5(f"{patient_id}+{study_id}+{series_id}".encode()).hexdigest()
+    else:
+        key = md5(f"{patient_id}+{study_id}+{series_id}".encode(), usedforsecurity=False).hexdigest()
+    return key
 
 
 def get_scu(query, output_dir, query_level="SERIES", host="127.0.0.1", port="4242", aet="MONAILABEL"):

--- a/monailabel/datastore/utils/dicom.py
+++ b/monailabel/datastore/utils/dicom.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def generate_key(patient_id: str, study_id: str, series_id: str):
-    return md5(f"{patient_id}+{study_id}+{series_id}".encode()).hexdigest()
+    return md5(f"{patient_id}+{study_id}+{series_id}".encode(), usedforsecurity=False).hexdigest()
 
 
 def get_scu(query, output_dir, query_level="SERIES", host="127.0.0.1", port="4242", aet="MONAILABEL"):

--- a/monailabel/datastore/xnat.py
+++ b/monailabel/datastore/xnat.py
@@ -41,7 +41,7 @@ class XNATDatastore(Datastore):
         self.projects = {p.strip() for p in self.projects}
         self.asset_path = asset_path
 
-        uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
+        uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         cache_path = cache_path.strip() if cache_path else ""
         self.cache_path = (
             os.path.join(cache_path, uri_hash)

--- a/monailabel/datastore/xnat.py
+++ b/monailabel/datastore/xnat.py
@@ -13,6 +13,7 @@ import hashlib
 import io
 import logging
 import os
+import sys
 import pathlib
 import shutil
 import time
@@ -40,8 +41,12 @@ class XNATDatastore(Datastore):
         self.projects = project.split(",") if project else []
         self.projects = {p.strip() for p in self.projects}
         self.asset_path = asset_path
-
-        uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        
+        uri_hash = ""
+        if sys.version_info.minor < 9:
+            uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
+        else:
+            uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
         cache_path = cache_path.strip() if cache_path else ""
         self.cache_path = (
             os.path.join(cache_path, uri_hash)

--- a/monailabel/datastore/xnat.py
+++ b/monailabel/datastore/xnat.py
@@ -13,9 +13,9 @@ import hashlib
 import io
 import logging
 import os
-import sys
 import pathlib
 import shutil
+import sys
 import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
@@ -41,7 +41,7 @@ class XNATDatastore(Datastore):
         self.projects = project.split(",") if project else []
         self.projects = {p.strip() for p in self.projects}
         self.asset_path = asset_path
-        
+
         uri_hash = ""
         if sys.version_info.minor < 9:
             uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()

--- a/monailabel/datastore/xnat.py
+++ b/monailabel/datastore/xnat.py
@@ -9,13 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import io
 import logging
 import os
 import pathlib
 import shutil
-import sys
 import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
@@ -25,6 +23,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from monailabel.interfaces.datastore import Datastore
+from monailabel.utils.others.generic import md5_digest
 
 logger = logging.getLogger(__name__)
 xnat_ns = {"xnat": "http://nrg.wustl.edu/xnat"}
@@ -42,11 +41,7 @@ class XNATDatastore(Datastore):
         self.projects = {p.strip() for p in self.projects}
         self.asset_path = asset_path
 
-        uri_hash = ""
-        if sys.version_info.minor < 9:
-            uri_hash = hashlib.md5(api_url.encode("utf-8")).hexdigest()
-        else:
-            uri_hash = hashlib.md5(api_url.encode("utf-8"), usedforsecurity=False).hexdigest()
+        uri_hash = md5_digest(api_url)
         cache_path = cache_path.strip() if cache_path else ""
         self.cache_path = (
             os.path.join(cache_path, uri_hash)

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -13,8 +13,8 @@ import copy
 import hashlib
 import logging
 import os
-import sys
 import pathlib
+import sys
 from typing import Hashable, Sequence, Tuple, Union
 
 import torch
@@ -68,12 +68,10 @@ class CacheTransformDatad(Transform):
 
     def load(self, data):
         d = dict(data)
-        
+
         hash_key_prefix = ""
         if sys.version_info.minor < 9:
-            hash_key_prefix = hashlib.md5(
-                "".join([d[k] for k in self.hash_key]).encode("utf-8")
-            ).hexdigest()
+            hash_key_prefix = hashlib.md5("".join([d[k] for k in self.hash_key]).encode("utf-8")).hexdigest()
         else:
             hash_key_prefix = hashlib.md5(
                 "".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -67,7 +67,7 @@ class CacheTransformDatad(Transform):
 
     def load(self, data):
         d = dict(data)
-        hash_key_prefix = hashlib.md5("".join([d[k] for k in self.hash_key]).encode("utf-8")).hexdigest()
+        hash_key_prefix = hashlib.md5("".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False).hexdigest()
 
         # full dictionary
         if not self.keys:
@@ -90,7 +90,7 @@ class CacheTransformDatad(Transform):
         d = dict(data)
 
         hash_keys = [d[k] for k in self.hash_key if d.get(k)]
-        hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8")).hexdigest()
+        hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8"), usedforsecurity=False).hexdigest()
         if len(hash_keys) != len(self.hash_key):
             logger.warning(f"Ignore caching; Missing hash keys;  Found: {hash_keys}; Expected: {self.hash_key}")
             return d

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -10,11 +10,9 @@
 # limitations under the License.
 
 import copy
-import hashlib
 import logging
 import os
 import pathlib
-import sys
 from typing import Hashable, Sequence, Tuple, Union
 
 import torch
@@ -25,6 +23,7 @@ from monai.transforms import Transform
 from monai.utils import ensure_tuple
 
 from monailabel.utils.sessions import Sessions
+from monailabel.utils.others.generic import md5_digest
 
 logger = logging.getLogger(__name__)
 
@@ -69,13 +68,7 @@ class CacheTransformDatad(Transform):
     def load(self, data):
         d = dict(data)
 
-        hash_key_prefix = ""
-        if sys.version_info.minor < 9:
-            hash_key_prefix = hashlib.md5("".join([d[k] for k in self.hash_key]).encode("utf-8")).hexdigest()
-        else:
-            hash_key_prefix = hashlib.md5(
-                "".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False
-            ).hexdigest()
+        hash_key_prefix = md5_digest("".join([d[k] for k in self.hash_key]))
 
         # full dictionary
         if not self.keys:
@@ -98,11 +91,7 @@ class CacheTransformDatad(Transform):
         d = dict(data)
 
         hash_keys = [d[k] for k in self.hash_key if d.get(k)]
-        hash_key_prefix = ""
-        if sys.version_info.minor < 9:
-            hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8")).hexdigest()
-        else:
-            hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8"), usedforsecurity=False).hexdigest()
+        hash_key_prefix = md5_digest("".join(hash_keys))
 
         if len(hash_keys) != len(self.hash_key):
             logger.warning(f"Ignore caching; Missing hash keys;  Found: {hash_keys}; Expected: {self.hash_key}")

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -98,7 +98,12 @@ class CacheTransformDatad(Transform):
         d = dict(data)
 
         hash_keys = [d[k] for k in self.hash_key if d.get(k)]
-        hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8"), usedforsecurity=False).hexdigest()
+        hash_key_prefix = ""
+        if sys.version_info.minor < 9:
+            hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8")).hexdigest()
+        else:
+            hash_key_prefix = hashlib.md5("".join(hash_keys).encode("utf-8"), usedforsecurity=False).hexdigest()
+
         if len(hash_keys) != len(self.hash_key):
             logger.warning(f"Ignore caching; Missing hash keys;  Found: {hash_keys}; Expected: {self.hash_key}")
             return d

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -67,7 +67,9 @@ class CacheTransformDatad(Transform):
 
     def load(self, data):
         d = dict(data)
-        hash_key_prefix = hashlib.md5("".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False).hexdigest()
+        hash_key_prefix = hashlib.md5(
+            "".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
 
         # full dictionary
         if not self.keys:

--- a/monailabel/transform/cache.py
+++ b/monailabel/transform/cache.py
@@ -13,6 +13,7 @@ import copy
 import hashlib
 import logging
 import os
+import sys
 import pathlib
 from typing import Hashable, Sequence, Tuple, Union
 
@@ -67,9 +68,16 @@ class CacheTransformDatad(Transform):
 
     def load(self, data):
         d = dict(data)
-        hash_key_prefix = hashlib.md5(
-            "".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False
-        ).hexdigest()
+        
+        hash_key_prefix = ""
+        if sys.version_info.minor < 9:
+            hash_key_prefix = hashlib.md5(
+                "".join([d[k] for k in self.hash_key]).encode("utf-8")
+            ).hexdigest()
+        else:
+            hash_key_prefix = hashlib.md5(
+                "".join([d[k] for k in self.hash_key]).encode("utf-8"), usedforsecurity=False
+            ).hexdigest()
 
         # full dictionary
         if not self.keys:

--- a/monailabel/utils/others/class_utils.py
+++ b/monailabel/utils/others/class_utils.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import glob
-import hashlib
 import importlib.util
 import inspect
 import logging

--- a/monailabel/utils/others/class_utils.py
+++ b/monailabel/utils/others/class_utils.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import glob
 import importlib.util
 import inspect

--- a/monailabel/utils/others/class_utils.py
+++ b/monailabel/utils/others/class_utils.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import glob
 import importlib.util
 import inspect

--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -15,6 +15,7 @@ import json
 import logging
 import mimetypes
 import os
+import sys
 import pathlib
 import re
 import shutil
@@ -385,3 +386,9 @@ def handle_torch_linalg_multithread(req):
             torch.inverse(torch.eye(1, device=req.get("device") if req else None))
     except RuntimeError:
         pass
+
+
+def md5_digest(s:str) -> str:
+    if sys.version_info.minor < 9:
+        return hashlib.md5(s.encode("utf-8")).hexdigest()
+    return hashlib.md5(s.encode("utf-8"), usedforsecurity=False).hexdigest()

--- a/tests/unit/endpoints/test_dicomwebcache.py
+++ b/tests/unit/endpoints/test_dicomwebcache.py
@@ -12,6 +12,7 @@
 import hashlib
 import json
 import os
+import sys
 import unittest
 from typing import Dict
 from unittest.mock import patch
@@ -64,9 +65,13 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
 
     @patch("monailabel.interfaces.app.DICOMwebClientX")
     def test_datastore_stats(self, dwc):
-        cache_path = os.path.join(
-            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        )
+        cache_hash = ""
+        if sys.version_info.minor < 9:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
+        else:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        cache_path = os.path.join(self.data_dir, cache_hash)
+
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -91,9 +96,13 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_all(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(
-            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        )
+        cache_hash = ""
+        if sys.version_info.minor < 9:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
+        else:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        cache_path = os.path.join(self.data_dir, cache_hash)
+
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -120,9 +129,13 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_save_label(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(
-            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        )
+        cache_hash = ""
+        if sys.version_info.minor < 9:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
+        else:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        cache_path = os.path.join(self.data_dir, cache_hash)
+
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -154,9 +167,13 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_train(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(
-            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        )
+        cache_hash = ""
+        if sys.version_info.minor < 9:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
+        else:
+            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        cache_path = os.path.join(self.data_dir, cache_hash)
+
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(

--- a/tests/unit/endpoints/test_dicomwebcache.py
+++ b/tests/unit/endpoints/test_dicomwebcache.py
@@ -64,7 +64,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
 
     @patch("monailabel.interfaces.app.DICOMwebClientX")
     def test_datastore_stats(self, dwc):
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
+        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -89,7 +89,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_all(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
+        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -116,7 +116,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_save_label(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
+        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -148,7 +148,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_train(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8")).hexdigest())
+        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(

--- a/tests/unit/endpoints/test_dicomwebcache.py
+++ b/tests/unit/endpoints/test_dicomwebcache.py
@@ -64,7 +64,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
 
     @patch("monailabel.interfaces.app.DICOMwebClientX")
     def test_datastore_stats(self, dwc):
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
+        cache_path = os.path.join(
+            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        )
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -89,7 +91,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_all(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
+        cache_path = os.path.join(
+            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        )
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -116,7 +120,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_save_label(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
+        cache_path = os.path.join(
+            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        )
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -148,7 +154,9 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_train(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_path = os.path.join(self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest())
+        cache_path = os.path.join(
+            self.data_dir, hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
+        )
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(

--- a/tests/unit/endpoints/test_dicomwebcache.py
+++ b/tests/unit/endpoints/test_dicomwebcache.py
@@ -9,10 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import json
 import os
-import sys
 import unittest
 from typing import Dict
 from unittest.mock import patch
@@ -20,6 +18,7 @@ from unittest.mock import patch
 import pydicom
 
 from monailabel.datastore.dicom import DICOMWebDatastore
+from monailabel.utils.others.generic import md5_digest
 
 from .context import DICOMWebEndpointTestSuite
 
@@ -65,12 +64,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
 
     @patch("monailabel.interfaces.app.DICOMwebClientX")
     def test_datastore_stats(self, dwc):
-        cache_hash = ""
-        if sys.version_info.minor < 9:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
-        else:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        cache_path = os.path.join(self.data_dir, cache_hash)
+        cache_path = os.path.join(self.data_dir, md5_digest(self.studies))
 
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
@@ -96,13 +90,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_all(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_hash = ""
-        if sys.version_info.minor < 9:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
-        else:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        cache_path = os.path.join(self.data_dir, cache_hash)
-
+        cache_path = os.path.join(self.data_dir, md5_digest(self.studies))
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -129,13 +117,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_save_label(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_hash = ""
-        if sys.version_info.minor < 9:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
-        else:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        cache_path = os.path.join(self.data_dir, cache_hash)
-
+        cache_path = os.path.join(self.data_dir, md5_digest(self.studies))
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(
@@ -167,13 +149,7 @@ class EndPointDICOMWebDatastore(DICOMWebEndpointTestSuite):
     def test_datastore_train(self, dicom_web_download_series, dwc):
         dicom_web_download_series.return_value = lambda *args: None
 
-        cache_hash = ""
-        if sys.version_info.minor < 9:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8")).hexdigest()
-        else:
-            cache_hash = hashlib.md5(self.studies.encode("utf-8"), usedforsecurity=False).hexdigest()
-        cache_path = os.path.join(self.data_dir, cache_hash)
-
+        cache_path = os.path.join(self.data_dir, md5_digest(self.studies))
         dwc.return_value.base_url = self.studies
         dwc.return_value.search_for_series = lambda **kwargs: search_for_series(self.data_dir, **kwargs)
         dwc.return_value.retrieve_series_metadata = lambda *args, **kwargs: retrieve_series_metadata(


### PR DESCRIPTION
MD5 hashing is not allowed in FIPS enabled machines for security. A simple fix is to use the `usedforsecurity=False` flag in the `md5()` calls.