### PR TITLE
Fix loading of a next sample for Slicer3D

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1028,7 +1028,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.saveServerUrl()
 
     def serverUrl(self):
-        serverUrl = self.ui.serverComboBox.currentText
+        serverUrl = self.ui.serverComboBox.currentText.strip()
         if not serverUrl:
             serverUrl = "http://127.0.0.1:8000"
         return serverUrl.rstrip("/")


### PR DESCRIPTION
Next Sample was not loading as MONAILabel extension was not stripping
`\n` character from extracted URL. This caused the URL to be invalid.