### PR TITLE
Fix silent fail if network loads wrong weights

### DIFF
--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -452,14 +452,17 @@ class BasicInferTask(InferTask):
 
                 if path:
                     checkpoint = torch.load(path, map_location=torch.device(device))
-                    for key in self.model_state_dict:
-                        if key not in checkpoint:
-                            logger.warning(
-                                f"Expected key {key} has not been found in the checkpoint keys: {checkpoint.keys()}"
-                            )
-                            logger.warning("The run will now continue unless load_strict is set to True")
-                            break
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
+
+                    if set(self.network.state_dict().keys()) != set(checkpoint.keys()):
+                        logger.warning(
+                            f"Checkpoint keys don't match network.state_dict()! Items that exist in only one dict"
+                            f" but not in the other: {set(self.network.state_dict().keys()) ^ set(checkpoint.keys())}"
+                        )
+                        logger.warning(
+                                "The run will now continue unless load_strict is set to True. "
+                                "If loading fails or the network behaves abnormally, please check the loaded weights"
+                        )
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:
                 network = torch.jit.load(path, map_location=torch.device(device))

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -57,7 +57,7 @@ class BasicInferTask(InferTask):
         output_label_key: str = "pred",
         output_json_key: str = "result",
         config: Union[None, Dict[str, Any]] = None,
-        load_strict: bool = False,
+        load_strict: bool = True,
         roi_size=None,
         preload=False,
         train_mode=False,
@@ -452,6 +452,13 @@ class BasicInferTask(InferTask):
 
                 if path:
                     checkpoint = torch.load(path, map_location=torch.device(device))
+                    for key in self.model_state_dict:
+                        if key not in checkpoint:
+                            logger.warning(
+                                f"Expected key {key} has not been found in the checkpoint keys: {checkpoint.keys()}"
+                            )
+                            logger.warning("The run will now continue unless load_strict is set to True")
+                            break
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -460,8 +460,8 @@ class BasicInferTask(InferTask):
                             f" but not in the other: {set(self.network.state_dict().keys()) ^ set(checkpoint.keys())}"
                         )
                         logger.warning(
-                                "The run will now continue unless load_strict is set to True. "
-                                "If loading fails or the network behaves abnormally, please check the loaded weights"
+                            "The run will now continue unless load_strict is set to True. "
+                            "If loading fails or the network behaves abnormally, please check the loaded weights"
                         )
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:

--- a/sample-apps/radiology/lib/infers/deepedit.py
+++ b/sample-apps/radiology/lib/infers/deepedit.py
@@ -71,6 +71,7 @@ class DeepEdit(BasicInferTask):
         self.spatial_size = spatial_size
         self.target_spacing = target_spacing
         self.number_intensity_ch = number_intensity_ch
+        self.load_strict = False
 
     def pre_transforms(self, data=None):
         t = [


### PR DESCRIPTION
This is a draft for fixing https://github.com/Project-MONAI/MONAILabel/issues/1508 .  It sets load_strict to False in basic_infer.py, also adds a warning in case load_strict is False but the model does not contain all the necessary keys.
Most importanly this PR helps the creation of new models where one might not even realize that the loaded network does not contain the necessary keys, which is what happened to me.

For default the DeepEdit the warning looks like this:
![image](https://github.com/Project-MONAI/MONAILabel/assets/7548699/9898fd7c-c6f2-4b69-95c1-47bec5fd5cbd)

It is a bit hidden, but nevertheless if anyone where to debug the code, this should probably help.

Todo:
- [ ] Is this solution a valid solution for everyone?
- [ ] Add load_strict=False to all existing models (only done for DeepEdit so far)