### PR TITLE
Fix network loading

### DIFF
--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -452,14 +452,17 @@ class BasicInferTask(InferTask):
 
                 if path:
                     checkpoint = torch.load(path, map_location=torch.device(device))
-                    for key in self.model_state_dict:
-                        if key not in checkpoint:
-                            logger.warning(
-                                f"Expected key {key} has not been found in the checkpoint keys: {checkpoint.keys()}"
-                            )
-                            logger.warning("The run will now continue unless load_strict is set to True")
-                            break
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
+
+                    if set(self.network.state_dict().keys()) != set(checkpoint.keys()):
+                        logger.warning(
+                            f"Checkpoint keys don't match network.state_dict()! Items that exist in only one dict"
+                            f" but not in the other: {set(self.network.state_dict().keys()) ^ set(checkpoint.keys())}"
+                        )
+                        logger.warning(
+                                "The run will now continue unless load_strict is set to True. "
+                                "If loading fails or the network behaves abnormally, please check the loaded weights"
+                        )
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:
                 network = torch.jit.load(path, map_location=torch.device(device))

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -57,7 +57,7 @@ class BasicInferTask(InferTask):
         output_label_key: str = "pred",
         output_json_key: str = "result",
         config: Union[None, Dict[str, Any]] = None,
-        load_strict: bool = False,
+        load_strict: bool = True,
         roi_size=None,
         preload=False,
         train_mode=False,
@@ -452,6 +452,13 @@ class BasicInferTask(InferTask):
 
                 if path:
                     checkpoint = torch.load(path, map_location=torch.device(device))
+                    for key in self.model_state_dict:
+                        if key not in checkpoint:
+                            logger.warning(
+                                f"Expected key {key} has not been found in the checkpoint keys: {checkpoint.keys()}"
+                            )
+                            logger.warning("The run will now continue unless load_strict is set to True")
+                            break
                     model_state_dict = checkpoint.get(self.model_state_dict, checkpoint)
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:

--- a/monailabel/tasks/infer/basic_infer.py
+++ b/monailabel/tasks/infer/basic_infer.py
@@ -460,8 +460,8 @@ class BasicInferTask(InferTask):
                             f" but not in the other: {set(self.network.state_dict().keys()) ^ set(checkpoint.keys())}"
                         )
                         logger.warning(
-                                "The run will now continue unless load_strict is set to True. "
-                                "If loading fails or the network behaves abnormally, please check the loaded weights"
+                            "The run will now continue unless load_strict is set to True. "
+                            "If loading fails or the network behaves abnormally, please check the loaded weights"
                         )
                     network.load_state_dict(model_state_dict, strict=self.load_strict)
             else:

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -87,6 +87,7 @@ class BundleInferTask(BasicInferTask):
         extend_load_image: bool = True,
         add_post_restore: bool = True,
         dropout: float = 0.0,
+        load_strict=False,
         **kwargs,
     ):
         self.valid: bool = False
@@ -149,7 +150,7 @@ class BundleInferTask(BasicInferTask):
             dimension=dimension,
             description=description,
             preload=strtobool(conf.get("preload", "false")),
-            load_strict=False,
+            load_strict=load_strict,
             **kwargs,
         )
 

--- a/monailabel/tasks/infer/bundle.py
+++ b/monailabel/tasks/infer/bundle.py
@@ -149,6 +149,7 @@ class BundleInferTask(BasicInferTask):
             dimension=dimension,
             description=description,
             preload=strtobool(conf.get("preload", "false")),
+            load_strict=False,
             **kwargs,
         )
 

--- a/sample-apps/endoscopy/lib/infers/deepedit.py
+++ b/sample-apps/endoscopy/lib/infers/deepedit.py
@@ -55,6 +55,7 @@ class DeepEdit(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
 

--- a/sample-apps/endoscopy/lib/infers/inbody.py
+++ b/sample-apps/endoscopy/lib/infers/inbody.py
@@ -24,7 +24,7 @@ class InBody(BundleInferTask):
     """
 
     def __init__(self, path: str, conf: Dict[str, str], **kwargs):
-        super().__init__(path, conf, type=InferType.CLASSIFICATION, add_post_restore=False, **kwargs)
+        super().__init__(path, conf, type=InferType.CLASSIFICATION, add_post_restore=False, load_strict=False, **kwargs)
 
         # Override Labels
         self.labels = {"InBody": 0, "OutBody": 1}

--- a/sample-apps/endoscopy/lib/infers/tooltracking.py
+++ b/sample-apps/endoscopy/lib/infers/tooltracking.py
@@ -28,7 +28,7 @@ class ToolTracking(BundleInferTask):
     """
 
     def __init__(self, path: str, conf: Dict[str, str], **kwargs):
-        super().__init__(path, conf, type=InferType.SEGMENTATION, **kwargs)
+        super().__init__(path, conf, type=InferType.SEGMENTATION, load_strict=False, **kwargs)
 
         # Override Labels
         self.labels = {"Tool": 1}

--- a/sample-apps/pathology/lib/infers/classification_nuclei.py
+++ b/sample-apps/pathology/lib/infers/classification_nuclei.py
@@ -24,7 +24,7 @@ class ClassificationNuclei(BundleInferTask):
     """
 
     def __init__(self, path: str, conf: Dict[str, str], **kwargs):
-        super().__init__(path, conf, type=InferType.CLASSIFICATION, add_post_restore=False, **kwargs)
+        super().__init__(path, conf, type=InferType.CLASSIFICATION, add_post_restore=False, load_strict=False, **kwargs)
 
         # Override Labels
         self.labels = {

--- a/sample-apps/pathology/lib/infers/nuclick.py
+++ b/sample-apps/pathology/lib/infers/nuclick.py
@@ -41,6 +41,7 @@ class NuClick(BundleInferTask):
             **kwargs,
             pre_filter=[LoadImaged, SqueezeDimd],
             post_filter=[KeepLargestConnectedComponentd, SaveImaged],
+            load_strict=False,
         )
 
         # Override Labels

--- a/sample-apps/pathology/lib/infers/nuclick.py
+++ b/sample-apps/pathology/lib/infers/nuclick.py
@@ -38,10 +38,10 @@ class NuClick(BundleInferTask):
             conf,
             type=InferType.ANNOTATION,
             add_post_restore=False,
+            load_strict=False,
             **kwargs,
             pre_filter=[LoadImaged, SqueezeDimd],
             post_filter=[KeepLargestConnectedComponentd, SaveImaged],
-            load_strict=False,
         )
 
         # Override Labels

--- a/sample-apps/pathology/lib/infers/segmentation_nuclei.py
+++ b/sample-apps/pathology/lib/infers/segmentation_nuclei.py
@@ -48,6 +48,7 @@ class SegmentationNuclei(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
 

--- a/sample-apps/radiology/lib/infers/deepedit.py
+++ b/sample-apps/radiology/lib/infers/deepedit.py
@@ -71,6 +71,7 @@ class DeepEdit(BasicInferTask):
         self.spatial_size = spatial_size
         self.target_spacing = target_spacing
         self.number_intensity_ch = number_intensity_ch
+        self.load_strict = False
 
     def pre_transforms(self, data=None):
         t = [

--- a/sample-apps/radiology/lib/infers/deepedit.py
+++ b/sample-apps/radiology/lib/infers/deepedit.py
@@ -65,6 +65,7 @@ class DeepEdit(BasicInferTask):
             input_key="image",
             output_label_key="pred",
             output_json_key="result",
+            load_strict=False,
             **kwargs,
         )
 

--- a/sample-apps/radiology/lib/infers/deepgrow.py
+++ b/sample-apps/radiology/lib/infers/deepgrow.py
@@ -63,6 +63,7 @@ class Deepgrow(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
 

--- a/sample-apps/radiology/lib/infers/deepgrow_pipeline.py
+++ b/sample-apps/radiology/lib/infers/deepgrow_pipeline.py
@@ -68,6 +68,7 @@ class InferDeepgrowPipeline(BasicInferTask):
             dimension=dimension,
             description=description,
             config={"cache_transforms": True, "cache_transforms_in_memory": True, "cache_transforms_ttl": 300},
+            load_strict=False,
         )
         self.model_3d = model_3d
         self.spatial_size = spatial_size
@@ -78,6 +79,8 @@ class InferDeepgrowPipeline(BasicInferTask):
         self.max_random_points = max_random_points
         self.random_point_density = random_point_density
         self.output_largest_cc = output_largest_cc
+
+        self.load_strict = False
 
     def pre_transforms(self, data=None) -> Sequence[Callable]:
         t = [

--- a/sample-apps/radiology/lib/infers/deepgrow_pipeline.py
+++ b/sample-apps/radiology/lib/infers/deepgrow_pipeline.py
@@ -80,8 +80,6 @@ class InferDeepgrowPipeline(BasicInferTask):
         self.random_point_density = random_point_density
         self.output_largest_cc = output_largest_cc
 
-        self.load_strict = False
-
     def pre_transforms(self, data=None) -> Sequence[Callable]:
         t = [
             LoadImaged(keys="image"),

--- a/sample-apps/radiology/lib/infers/localization_spine.py
+++ b/sample-apps/radiology/lib/infers/localization_spine.py
@@ -54,6 +54,7 @@ class LocalizationSpine(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
         self.target_spacing = target_spacing

--- a/sample-apps/radiology/lib/infers/localization_vertebra.py
+++ b/sample-apps/radiology/lib/infers/localization_vertebra.py
@@ -56,6 +56,7 @@ class LocalizationVertebra(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
         self.target_spacing = target_spacing

--- a/sample-apps/radiology/lib/infers/segmentation.py
+++ b/sample-apps/radiology/lib/infers/segmentation.py
@@ -54,6 +54,7 @@ class Segmentation(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
         self.target_spacing = target_spacing

--- a/sample-apps/radiology/lib/infers/segmentation_spleen.py
+++ b/sample-apps/radiology/lib/infers/segmentation_spleen.py
@@ -53,6 +53,7 @@ class SegmentationSpleen(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
         self.target_spacing = target_spacing

--- a/sample-apps/radiology/lib/infers/segmentation_vertebra.py
+++ b/sample-apps/radiology/lib/infers/segmentation_vertebra.py
@@ -63,6 +63,7 @@ class SegmentationVertebra(BasicInferTask):
             labels=labels,
             dimension=dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
         self.target_spacing = target_spacing

--- a/sample-apps/radiology/lib/infers/vertebra_pipeline.py
+++ b/sample-apps/radiology/lib/infers/vertebra_pipeline.py
@@ -47,6 +47,7 @@ class InferVertebraPipeline(BasicInferTask):
             labels=task_seg_vertebra.labels,
             dimension=task_seg_vertebra.dimension,
             description=description,
+            load_strict=False,
             **kwargs,
         )
 


### PR DESCRIPTION
This is the missing code for #1521, where I missunderstood @SachidanandAlle.

The code sets the default value `load_strict=False` of `BasicInferTask` in the derived subclasses. The `BundleInferTask` also now matches the previous behavior.

The only model with a value of True is `HovernetNuclei` . 

This PR fixes the probably breaking network whenever values are missing, since the other PR enabled just that.