### PR TITLE
update numpymaxflow to v0.0.6 with py311 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pydicom-seg==0.4.1
 pynetdicom==2.0.2
 pynrrd==1.0.0
 opencv-python-headless==4.7.0.72
-numpymaxflow==0.0.5
+numpymaxflow==0.0.6
 girder-client==3.1.17
 ninja==1.11.1
 einops>=0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     pynetdicom==2.0.2
     pynrrd==1.0.0
     opencv-python-headless==4.7.0.72
-    numpymaxflow==0.0.5
+    numpymaxflow==0.0.6
     girder-client==3.1.17
     ninja==1.11.1
     einops>=0.6.0


### PR DESCRIPTION
As indicated in https://github.com/masadcv/numpymaxflow/pull/17 - the numpymaxflow library only worked until py3.10. 
This update will switch to version 0.0.6 of numpymaxflow that has precompiled binaries for py3.11 included as well as necessary code to compile should py3.12 be required in future