### PR TITLE
Add no scribbles model

### DIFF
--- a/sample-apps/radiology/README.md
+++ b/sample-apps/radiology/README.md
@@ -188,7 +188,8 @@ the model to learn on new organ.
 | Name                 | Values             | Description                                                     |
 |----------------------|--------------------|-----------------------------------------------------------------|
 | use_pretrained_model | **true**, false    | Disable this NOT to load any pretrained weights                 |
-| preload              | true, **false**    | Preload model into GPU                                                                                |
+| preload              | true, **false**    | Preload model into GPU                                          |
+| scribbles            | **true**, false    | Don't load the scribble models, useful for user studies         |
 
 - Network: This model uses the [UNet](https://docs.monai.io/en/latest/networks.html#unet) as the default network. Researchers can define their own network or use one of the listed [here](https://docs.monai.io/en/latest/networks.html)
 - Labels

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -66,6 +66,11 @@ class MyApp(MONAILabelApp):
 
         models = models.split(",")
         models = [m.strip() for m in models]
+        if "no_scribbles" in models:
+            self.no_scribbles = True
+            models.remove('no_scribbles')
+        else:
+            self.no_scribbles = False
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:
             print("")

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -143,26 +143,27 @@ class MyApp(MONAILabelApp):
         #################################################
         # Scribbles
         #################################################
-        infers.update(
-            {
-                "Histogram+GraphCut": HistogramBasedGraphCut(
-                    intensity_range=(-300, 200, 0.0, 1.0, True),
-                    pix_dim=(2.5, 2.5, 5.0),
-                    lamda=1.0,
-                    sigma=0.1,
-                    num_bins=64,
-                    labels=task_config.labels,
-                ),
-                "GMM+GraphCut": GMMBasedGraphCut(
-                    intensity_range=(-300, 200, 0.0, 1.0, True),
-                    pix_dim=(2.5, 2.5, 5.0),
-                    lamda=5.0,
-                    sigma=0.5,
-                    num_mixtures=20,
-                    labels=task_config.labels,
-                ),
-            }
-        )
+        if not self.no_scribbles:
+            infers.update(
+                {
+                    "Histogram+GraphCut": HistogramBasedGraphCut(
+                        intensity_range=(-300, 200, 0.0, 1.0, True),
+                        pix_dim=(2.5, 2.5, 5.0),
+                        lamda=1.0,
+                        sigma=0.1,
+                        num_bins=64,
+                        labels=task_config.labels,
+                    ),
+                    "GMM+GraphCut": GMMBasedGraphCut(
+                        intensity_range=(-300, 200, 0.0, 1.0, True),
+                        pix_dim=(2.5, 2.5, 5.0),
+                        lamda=5.0,
+                        sigma=0.5,
+                        num_mixtures=20,
+                        labels=task_config.labels,
+                    ),
+                }
+            )
 
         #################################################
         # Pipeline based on existing infers

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -68,7 +68,7 @@ class MyApp(MONAILabelApp):
         models = [m.strip() for m in models]
         if "no_scribbles" in models:
             self.no_scribbles = True
-            models.remove('no_scribbles')
+            models.remove("no_scribbles")
         else:
             self.no_scribbles = False
         invalid = [m for m in models if m != "all" and not configs.get(m)]

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -66,11 +66,8 @@ class MyApp(MONAILabelApp):
 
         models = models.split(",")
         models = [m.strip() for m in models]
-        if "no_scribbles" in models:
-            self.no_scribbles = True
-            models.remove("no_scribbles")
-        else:
-            self.no_scribbles = False
+        # Can be configured with --conf scribbles False or True
+        self.scribbles = conf.get("scribbles", "True") == "True"
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:
             print("")
@@ -143,7 +140,7 @@ class MyApp(MONAILabelApp):
         #################################################
         # Scribbles
         #################################################
-        if not self.no_scribbles:
+        if self.scribbles:
             infers.update(
                 {
                     "Histogram+GraphCut": HistogramBasedGraphCut(

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -67,7 +67,7 @@ class MyApp(MONAILabelApp):
         models = models.split(",")
         models = [m.strip() for m in models]
         # Can be configured with --conf scribbles False or True
-        self.scribbles = conf.get("scribbles", "True") == "True"
+        self.scribbles = conf.get("scribbles", "true") == "true"
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:
             print("")

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -66,7 +66,7 @@ class MyApp(MONAILabelApp):
 
         models = models.split(",")
         models = [m.strip() for m in models]
-        # Can be configured with --conf scribbles False or True
+        # Can be configured with --conf scribbles false or true
         self.scribbles = conf.get("scribbles", "true") == "true"
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:


### PR DESCRIPTION
I don't think this is the best approach to implement this behavior, however, it does work. I am open to implementing this in a completely different way if a maintainer can tell me how else to do this.
As it is this PR adds a new model called "no_scribbles". If you add this model, the scribbles section is deactivated. For an interactive user study I simply wanted to eliminate all possible sources of confusion and errors, since it is click only (interactive DeepEdit style).