### PR TITLE
Add feature "include dicom files"

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1485,7 +1485,11 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.reportProgress(30)
 
             self.updateServerSettings()
-            result = self.logic.save_label(self.current_sample["id"], label_in, {"label_info": label_info})
+            result = self.logic.save_label(
+                self.current_sample["id"],
+                label_in,
+                {"label_info": label_info, "model": model},
+            )
             self.fetchInfo()
 
             if slicer.util.settingsValue("MONAILabel/autoUpdateModelV2", False, converter=slicer.util.toBool):

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -193,7 +193,9 @@ class _ui_MONAILabelSettingsPanel:
 
         includeDicomFilesCheckBox = qt.QCheckBox()
         includeDicomFilesCheckBox.checked = False
-        includeDicomFilesCheckBox.toolTip = _("Enable this option to include dicom files in server-client data exchange")
+        includeDicomFilesCheckBox.toolTip = _(
+            "Enable this option to include dicom files in server-client data exchange"
+        )
         groupLayout.addRow(_("Include DICOM files:"), includeDicomFilesCheckBox)
         parent.registerProperty(
             "MONAILabel/includeDicomFiles",
@@ -1383,7 +1385,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def get_dicom_files(self):
         dicom_files = []
-        for path, _, files in os.walk(self.tmpdir):
+        for path, subdir, files in os.walk(self.tmpdir):
             for file in files:
                 if file[-3:] == "dcm":
                     dicom_files.append(os.path.join(path, file))
@@ -1430,9 +1432,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # if includeDicomFilesCheckBox is marked, save original dicom files on the client
                 if slicer.util.settingsValue("MONAILabel/includeDicomFiles", False, converter=slicer.util.toBool):
                     dcm_filenames = self.get_dicom_files()
-                    report_progress_increment = round(
-                        last_report_progress / len(dcm_filenames), 1
-                    )
+                    report_progress_increment = round(last_report_progress / len(dcm_filenames), 1)
                     for dcm_fullpath in dcm_filenames:
                         dcm_filename = dcm_fullpath.split("/")[-1]
                         dcm_filename = ".".join(dcm_filename.split(".")[:-1])
@@ -1588,7 +1588,7 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.current_sample.get("session"):
             if not self.onUploadImage(init_sample=False):
                 return
-        
+
         start = time.time()
         result_file = None
         try:

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1585,6 +1585,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if not self.current_sample:
             return
 
+        if self.current_sample.get("session"):
+            if not self.onUploadImage(init_sample=False):
+                return
+        
         start = time.time()
         result_file = None
         try:

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -190,6 +190,17 @@ class _ui_MONAILabelSettingsPanel:
             str(qt.SIGNAL("valueAsIntChanged(int)")),
         )
 
+        includeDicomFilesCheckBox = qt.QCheckBox()
+        includeDicomFilesCheckBox.checked = False
+        includeDicomFilesCheckBox.toolTip = _("Enable this option to include dicom files in server-client data exchange")
+        groupLayout.addRow(_("Include DICOM files:"), includeDicomFilesCheckBox)
+        parent.registerProperty(
+            "MONAILabel/includeDicomFiles",
+            ctk.ctkBooleanMapper(includeDicomFilesCheckBox, "checked", str(qt.SIGNAL("toggled(bool)"))),
+            "valueAsInt",
+            str(qt.SIGNAL("valueAsIntChanged(int)")),
+        )
+
         vBoxLayout.addWidget(groupBox)
         vBoxLayout.addStretch(1)
 

--- a/sample-apps/radiology/lib/transforms/transforms.py
+++ b/sample-apps/radiology/lib/transforms/transforms.py
@@ -384,11 +384,7 @@ class CropAndCreateSignald(MapTransform):
             ###########
             d["current_label"] = list(d["centroids"][0].values())[0][-4]
 
-            (
-                x,
-                y,
-                z,
-            ) = (
+            (x, y, z,) = (
                 list(d["centroids"][0].values())[0][-3],
                 list(d["centroids"][0].values())[0][-2],
                 list(d["centroids"][0].values())[0][-1],


### PR DESCRIPTION
First, I included the tag "model" in the dict "label_info" because I needed the name of the model that generated the label to be further saved.
Then, I included a checkBox in the plugin settings to enable dicom export between server and client. This feature is important because some models can use metadata included in the dicom header, such as slice thickness.
Finally, I added a function call to enable image upload right after segmentation is called, due to the same problem previously described.