### PR TITLE
Fix response encoding to explicitly use UTF-8 for HTTP response data

### DIFF
--- a/plugins/qupath/src/main/java/qupath/lib/extension/monailabel/MonaiLabelClient.java
+++ b/plugins/qupath/src/main/java/qupath/lib/extension/monailabel/MonaiLabelClient.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -190,7 +191,7 @@ public class MonaiLabelClient {
 
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder builder = factory.newDocumentBuilder();
-		InputStream inputStream = new ByteArrayInputStream(response.getBytes());
+		InputStream inputStream = new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8));
 		Document dom = builder.parse(inputStream);
 		return dom;
 	}


### PR DESCRIPTION
Previously, the code used `response.getBytes()` which might rely on the platform's default charset to encode the HTTP response data, leading to inconsistent behavior across platforms. This commit updates the code to use `response.getBytes(StandardCharsets.UTF_8)`, specifying UTF-8 encoding explicitly for processing response data. This ensures cross-platform consistency and avoids potential encoding issues.