### PR TITLE
update github monai model zoo config

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -394,8 +394,6 @@ On the local machine follow the commands listed below to install MONAI Label, an
   monailabel datasets --download --name Task09_Spleen --output .
 
   # start the bundle app in MONAI label server
-  # the MONAI Bundle app requires access to MODEL ZOO, please set the authentication token first.
-  export MONAI_ZOO_AUTH_TOKEN=<Your github auth token>
   # and start annotating the images using bundle with the Swin UNETR bundle
   monailabel start_server --app monaibundle --studies Task09_Spleen/imagesTr --conf models swin_unetr_btcv_segmentation
 
@@ -450,7 +448,6 @@ Prerequisite: Check Model Zoo `Release <https://github.com/Project-MONAI/model-z
 
   # Step 4: start the bundle app in MONAI label server
   # the MONAI Bundle app requires access to MODEL ZOO, please set the authentication token first.
-  export MONAI_ZOO_AUTH_TOKEN=<Your github auth token>
   monailabel start_server --app monaibundle --studies Task09_Spleen/imagesTr --conf models renalStructures_UNEST_segmentation
 
 

--- a/monailabel/utils/others/generic.py
+++ b/monailabel/utils/others/generic.py
@@ -255,22 +255,11 @@ def is_openslide_supported(name):
 
 def get_zoo_bundle(model_dir, conf, models, conf_key):
     zoo_repo = conf.get("zoo_repo", settings.MONAI_ZOO_REPO)
-    auth_token = conf.get("auth_token", settings.MONAI_ZOO_AUTH_TOKEN)
-    auth_token = auth_token if auth_token else None
-    try:
-        zoo_info = get_all_bundles_list(auth_token=auth_token)
-    except:
-        print("")
-        print("---------------------------------------------------------------------------------------")
-        print(
-            "Github access rate limit reached, please provide personal auth token by setting env MONAI_ZOO_AUTH_TOKEN"
-        )
-        print("or --conf auth_token <personal auth token>")
-        exit(-1)
+    zoo_info = get_all_bundles_list()
 
     # filter model zoo bundle with MONAI Label supported bundles according to the maintaining list, return all version bundles list
     available = [i[0] for i in zoo_info if i[0] in MAINTAINED_BUNDLES]
-    available_with_version = {b: get_bundle_versions(b, auth_token=auth_token)["all_versions"] for b in available}
+    available_with_version = {b: get_bundle_versions(b)["all_versions"] for b in available}
 
     available_both = available + [k + "_v" + v for k, versions in available_with_version.items() for v in versions]
 
@@ -316,7 +305,7 @@ def get_zoo_bundle(model_dir, conf, models, conf_key):
             if not os.path.exists(p):
                 name = k if k in available else version_to_name.get(k)
                 version = None if k in available else name_to_version.get(k)
-                download(name=name, version=version, bundle_dir=model_dir, source="github", repo=zoo_repo)
+                download(name=name, version=version, bundle_dir=model_dir, source="monaihosting", repo=zoo_repo)
                 if version:
                     shutil.move(os.path.join(model_dir, name), p)
         bundles[k] = p
@@ -350,7 +339,7 @@ def get_bundle_models(app_dir, conf, conf_key="models"):
     models = models.split(",")
     models = [m.strip() for m in models]
 
-    if zoo_source == "github":  # if in github env, access model zoo
+    if zoo_source == "monaihosting":  # if in github env, access model zoo
         bundles = get_zoo_bundle(model_dir, conf, models, conf_key)
     else:  # if not in github env, no "model zoo" access, users either provide bundles locally, or auto download with latest
         bundles: Dict[str, str] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ python-jose[cryptography]==3.3.0
 bcrypt==4.0.1
 shapely==2.0.1
 requests==2.31.0
+urllib3==1.26.11
 requests-toolbelt
 scikit-learn
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ passlib==1.7.4
 python-jose[cryptography]==3.3.0
 bcrypt==4.0.1
 shapely==2.0.1
-requests
+requests==2.31.0
 requests-toolbelt
 scikit-learn
 scipy

--- a/sample-apps/monaibundle/README.md
+++ b/sample-apps/monaibundle/README.md
@@ -44,7 +44,6 @@ The MONAIBundle App currently supports most labeling models in the Model-Zoo. Yo
 | [lung_nodule_ct_detection](https://github.com/Project-MONAI/model-zoo/tree/dev/models/lung_nodule_ct_detection) | RetinaNet | Lung Nodule| CT | The detection model for 3D CT images |
 | [wholeBody_ct_segmentation](https://github.com/Project-MONAI/model-zoo/tree/dev/models/wholeBody_ct_segmentation) | SegResNet | 104 body structures| CT | The segmentation model for 104 tissue from 3D CT images (TotalSegmentator Dataset) |
 
-**Note:** The MONAIBundle app uses the MONAI Bundle API to retrieve information about the latest models from the Model-Zoo. If you're encountering rate limiting issues while using the app, you can input your personal access token using the --conf auth_token command. For more information on rate limiting and how to generate an access token, please refer to the following link: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
 
 ### How To Use the App
 
@@ -162,8 +161,6 @@ monailabel datasets --download --name Task06_Lung --output datasets
 All models, datasets, and plugins are ready, start the MONAI Label server and open 3D Slicer to annotate!
 
 ```bash
-# the MONAI Bundle app requires access to MODEL ZOO, please set the authentication token first.
-export MONAI_ZOO_AUTH_TOKEN=<Your github auth token>
 # 1: Use LUNA16 sample data
 monailabel start_server --app apps/monaibundle --studies datasets/Task06_Lung/imagesTr --conf models lung_nodule_ct_detection
 # 2: Use Task06_Lung data for inference demonstration

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ install_requires =
     bcrypt==4.0.1
     shapely==2.0.1
     requests==2.31.0
+    urllib3==1.26.11
     scikit-learn
     scipy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     python-jose[cryptography]==3.3.0
     bcrypt==4.0.1
     shapely==2.0.1
-    requests==2.28.2
+    requests==2.31.0
     scikit-learn
     scipy
 


### PR DESCRIPTION
Update some configs on download monai model zoo bundles. 
This can avoid rate limit errors, source="github" will no longer maintained. Change to monaihosting.