### PR TITLE
BUG: Fix traceback in restored transform

### DIFF
--- a/monailabel/transform/post.py
+++ b/monailabel/transform/post.py
@@ -129,7 +129,7 @@ class Restored(MapTransform):
             spatial_size = spatial_shape[-len(current_size) :]
 
             # Undo Spacing
-            if np.any(np.not_equal(current_size, spatial_size)):
+            if torch.any(torch.Tensor(np.not_equal(current_size, spatial_size))):
                 resizer = Resize(spatial_size=spatial_size, mode=self.mode[idx])
                 result = resizer(result, mode=self.mode[idx], align_corners=self.align_corners[idx])
 


### PR DESCRIPTION
Using transforms from MONAI and MONAILabel can result in metadata containing torch.tensors and torch.Sizes. This change fixes a traceback in the restored transform resulting from an incompatibility between torch datatypes and numpy.any().

Signed-off-by: Thomas Kierski <thomas.kierski@revvity.com>