### PR TITLE
Fix Release Build/setup.py for SAM2 dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ __pycache__
 .vscode
 .webpack
 node_modules/
+*.log
 
 # Environments
 .env

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -128,7 +128,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install "$tmp_dir"/monailabel*.whl[all]
+          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all]
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -128,7 +128,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install "$tmp_dir"/monailabel*.whl
+          python -m pip install "$tmp_dir"/monailabel*.whl[all]
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -128,7 +128,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all]
+          python -m pip install "$tmp_dir"/monailabel*.whl
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,11 @@ jobs:
           rm -rf /opt/hostedtoolcache
           sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
-          #python -m pip install torch torchvision
+          python -m pip install torch torchvision
       - name: Build Package
         run: |
           ./runtests.sh --clean
-          BUILD_OHIF=false python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
+          BUILD_OHIF=true python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
           ls -l dist
       - name: Verify Package
         run: |
@@ -65,7 +65,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all] 
+          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all]
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 
@@ -73,7 +73,7 @@ jobs:
           python -m pip install pytest
 
           # start the monailabel server in the background and run the integration tests
-          # ./runtests.sh --net
+          ./runtests.sh --net
 
           # cleanup
           python -m pip uninstall -y monailabel
@@ -91,7 +91,7 @@ jobs:
         run: |
           rm dist/monai*.tar.gz
 
-      - name: Publish distribution to Test PyPI
+      - name: Publish distribution to Test
         if: ${{ github.event.inputs.test_py == 'true' }}
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,11 @@ jobs:
           rm -rf /opt/hostedtoolcache
           sudo apt-get install openslide-tools -y
           python -m pip install --user --upgrade pip setuptools wheel
-          python -m pip install torch torchvision
+          #python -m pip install torch torchvision
       - name: Build Package
         run: |
           ./runtests.sh --clean
-          BUILD_OHIF=true python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
+          BUILD_OHIF=false python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
           ls -l dist
       - name: Verify Package
         run: |
@@ -65,7 +65,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install "$tmp_dir"/monailabel*.whl[all]
+          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all] 
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install "$tmp_dir"/monailabel*.whl
+          python -m pip install "$tmp_dir"/monailabel*.whl[all]
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 
@@ -73,7 +73,7 @@ jobs:
           python -m pip install pytest
 
           # start the monailabel server in the background and run the integration tests
-          ./runtests.sh --net
+          # ./runtests.sh --net
 
           # cleanup
           python -m pip uninstall -y monailabel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           rm -r build monailabel*.egg-info
 
           # install from wheel
-          python -m pip install `ls "$tmp_dir"/monailabel*.whl`[all]
+          python -m pip install "$tmp_dir"/monailabel*.whl
           python -c 'import monailabel; monailabel.print_config()' 2>&1 | grep -iv "unknown"
           python -c 'import monailabel; print(monailabel.__file__)'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ WORKDIR /opt/monailabel
 RUN apt update -y && apt install -y git curl openslide-tools python3 python-is-python3 python3-pip
 RUN python -m pip install --no-cache-dir pytest torch torchvision torchaudio
 COPY --from=build /opt/monailabel/dist/monailabel* /opt/monailabel/dist/
-RUN python -m pip install --no-cache-dir `ls /opt/monailabel/dist/monailabel*.whl`[all]
+RUN python -m pip install --no-cache-dir /opt/monailabel/dist/monailabel*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ WORKDIR /opt/monailabel
 RUN apt update -y && apt install -y git curl openslide-tools python3 python-is-python3 python3-pip
 RUN python -m pip install --no-cache-dir pytest torch torchvision torchaudio
 COPY --from=build /opt/monailabel/dist/monailabel* /opt/monailabel/dist/
-RUN python -m pip install --no-cache-dir /opt/monailabel/dist/monailabel*.whl
+RUN python -m pip install --no-cache-dir /opt/monailabel/dist/monailabel*.whl[all]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ WORKDIR /opt/monailabel
 RUN apt update -y && apt install -y git curl openslide-tools python3 python-is-python3 python3-pip
 RUN python -m pip install --no-cache-dir pytest torch torchvision torchaudio
 COPY --from=build /opt/monailabel/dist/monailabel* /opt/monailabel/dist/
-RUN python -m pip install --no-cache-dir /opt/monailabel/dist/monailabel*.whl[all]
+RUN python -m pip install --no-cache-dir `ls /opt/monailabel/dist/monailabel*.whl`[all]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,12 @@ RUN BUILD_OHIF=false python setup.py bdist_wheel --build-number $(date +'%Y%m%d%
 FROM ${FINAL_IMAGE}
 LABEL maintainer="monai.contact@gmail.com"
 WORKDIR /opt/monailabel
+COPY requirements.txt /opt/monailabel/requirements.txt
+
 RUN apt update -y && apt install -y git curl openslide-tools python3 python-is-python3 python3-pip
 RUN python -m pip install --no-cache-dir pytest torch torchvision torchaudio
+
 COPY --from=build /opt/monailabel/dist/monailabel* /opt/monailabel/dist/
-RUN python -m pip install --no-cache-dir /opt/monailabel/dist/monailabel*.whl
+RUN python -m pip install -v --no-cache-dir /opt/monailabel/dist/monailabel*.whl
+RUN python -m pip uninstall sam2 -y
+RUN python -m pip install -v --no-cache-dir -r /opt/monailabel/requirements.txt

--- a/README.md
+++ b/README.md
@@ -167,12 +167,6 @@ In addition, you can find a table of the basic supported fields, modalities, vie
 <tr>
 </table>
 
-> [**SAM2**](https://github.com/facebookresearch/sam2/)
->
-> By default, SAM2 is included for all the above Apps only when **_python >= 3.10_**
->  - **sam_2d**: for any organ or tissue and others over a given slice/2D image.
->  - **sam_3d**: to support SAM2 propagation over multiple slices (Radiology/MONAI-Bundle).
-
 # Getting Started with MONAI Label
 ### MONAI Label requires a few steps to get started:
 - Step 1: [Install MONAI Label](#step-1-installation)
@@ -185,7 +179,7 @@ In addition, you can find a table of the basic supported fields, modalities, vie
 
 ### Current Stable Version
 <a href="https://pypi.org/project/monailabel/#history"><img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/project-monai/monailabel"></a>
-<pre>pip install -U monailabel[all]</pre>
+<pre>pip install -U monailabel</pre>
 
 MONAI Label supports the following OS with **GPU/CUDA** enabled. For more details instruction, please see the installation guides.
 - [Ubuntu](https://docs.monai.io/projects/label/en/latest/installation.html)
@@ -218,6 +212,19 @@ To install the _**latest features**_ using one of the following options:
   <br>
   <pre>docker run --gpus all --rm -ti --ipc=host --net=host projectmonai/monailabel:latest bash</pre>
 </details>
+
+### SAM-2
+
+> By default, [**SAM2**](https://github.com/facebookresearch/sam2/) model is included for all the Apps when **_python >= 3.10_**
+>  - **sam_2d**: for any organ or tissue and others over a given slice/2D image.
+>  - **sam_3d**: to support SAM2 propagation over multiple slices (Radiology/MONAI-Bundle).
+
+If you are using `pip install monailabel` by default it uses [SAM-2](https://huggingface.co/facebook/sam2-hiera-large) models.
+<br/>
+To use [SAM-2.1](https://huggingface.co/facebook/sam2.1-hiera-large) use one of following options.
+ - Use monailabel [Docker](https://hub.docker.com/r/projectmonai/monailabel) instead of pip package
+ - Run monailabel in dev mode (git checkout)
+ - If you have installed monailabel via pip then uninstall **_sam2_** package `pip uninstall sam2` and then run `pip install -r requirements.txt` or install latest **SAM-2** from it's [github](https://github.com/facebookresearch/sam2/tree/main?tab=readme-ov-file#installation).
 
 ## Step 2 MONAI Label Sample Applications
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ In addition, you can find a table of the basic supported fields, modalities, vie
 
 ### Current Stable Version
 <a href="https://pypi.org/project/monailabel/#history"><img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/project-monai/monailabel"></a>
-<pre>pip install -U monailabel</pre>
+<pre>pip install -U monailabel[all]</pre>
 
 MONAI Label supports the following OS with **GPU/CUDA** enabled. For more details instruction, please see the installation guides.
 - [Ubuntu](https://docs.monai.io/projects/label/en/latest/installation.html)

--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -8,12 +8,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
+from importlib.util import find_spec
 from typing import Any, Dict, List, Optional
 
 from pydantic import AnyHttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def is_package_installed(name):
+    return False if find_spec(name) is None else True
 
 
 class Settings(BaseSettings):
@@ -97,6 +101,19 @@ class Settings(BaseSettings):
     MONAI_ZOO_SOURCE: str = os.environ.get("BUNDLE_DOWNLOAD_SRC", "monaihosting")
     MONAI_ZOO_REPO: str = "Project-MONAI/model-zoo/hosting_storage_v1"
     MONAI_ZOO_AUTH_TOKEN: str = ""
+
+    # Refer: https://github.com/facebookresearch/sam2?tab=readme-ov-file#model-description
+    # Refer: https://huggingface.co/facebook/sam2-hiera-large
+    MONAI_SAM_MODEL_PT = (
+        "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_large.pt"
+        if is_package_installed("SAM-2")
+        else "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_large.pt"
+    )
+    MONAI_SAM_MODEL_CFG = (
+        "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_l.yaml"
+        if is_package_installed("SAM-2")
+        else "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_l.yaml"
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -104,12 +104,12 @@ class Settings(BaseSettings):
 
     # Refer: https://github.com/facebookresearch/sam2?tab=readme-ov-file#model-description
     # Refer: https://huggingface.co/facebook/sam2-hiera-large
-    MONAI_SAM_MODEL_PT = (
+    MONAI_SAM_MODEL_PT: str = (
         "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_large.pt"
         if is_package_installed("SAM-2")
         else "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_large.pt"
     )
-    MONAI_SAM_MODEL_CFG = (
+    MONAI_SAM_MODEL_CFG: str = (
         "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_l.yaml"
         if is_package_installed("SAM-2")
         else "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_l.yaml"

--- a/monailabel/sam2/infer.py
+++ b/monailabel/sam2/infer.py
@@ -116,15 +116,8 @@ class Sam2InferTask(InferTask):
             self._config.update(config)
 
         # Download PreTrained Model
-        # https://github.com/facebookresearch/sam2?tab=readme-ov-file#model-description
-        # https://huggingface.co/facebook/sam2-hiera-large
-
-        pt_url = "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_large.pt"
-        conf_url = "https://huggingface.co/facebook/sam2.1-hiera-large/resolve/main/sam2.1_hiera_l.yaml"
-
-        # pt_url = "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_large.pt"
-        # conf_url = "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_l.yaml"
-
+        pt_url = settings.MONAI_SAM_MODEL_PT
+        conf_url = settings.MONAI_SAM_MODEL_CFG
         sam_pt = pt_url.split("/")[-1]
         sam_conf = conf_url.split("/")[-1]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ scikit-learn
 scipy
 google-auth==2.29.0
 SAM-2 @ git+https://github.com/facebookresearch/sam2.git@c2ec8e14a185632b0a5d8b161928ceb50197eddc ; python_version >= '3.10'
-
+#sam2>=0.4.1; python_version >= '3.10'
 
 # scipy and scikit-learn latest packages are missing on python 3.8
 # sudo apt-get install openslide-tools -y

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -58,9 +58,9 @@ class MyApp(MONAILabelApp):
             print(f"    all, {', '.join(configs.keys())}")
             print("---------------------------------------------------------------------------------------")
             print("")
-            exit(-1)
+            # exit(-1)
 
-        models = models.split(",")
+        models = models.split(",") if models else []
         models = [m.strip() for m in models]
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:
@@ -85,7 +85,7 @@ class MyApp(MONAILabelApp):
 
         logger.info(f"+++ Using Models: {list(self.models.keys())}")
 
-        self.sam = strtobool(conf.get("sam", "true"))
+        self.sam = strtobool(conf.get("sam2", "true"))
         super().__init__(
             app_dir=app_dir,
             studies=studies,

--- a/sample-apps/monaibundle/main.py
+++ b/sample-apps/monaibundle/main.py
@@ -46,7 +46,7 @@ class MyApp(MONAILabelApp):
             self.epistemic_simulation_size = int(conf.get("epistemic_simulation_size", "5"))
             self.epistemic_dropout = float(conf.get("epistemic_dropout", "0.2"))
 
-        self.sam = strtobool(conf.get("sam", "true"))
+        self.sam = strtobool(conf.get("sam2", "true"))
         super().__init__(
             app_dir=app_dir,
             studies=studies,

--- a/sample-apps/pathology/main.py
+++ b/sample-apps/pathology/main.py
@@ -54,7 +54,7 @@ class MyApp(MONAILabelApp):
 
         configs = {k: v for k, v in sorted(configs.items())}
 
-        models = conf.get("models", "all")
+        models = conf.get("models")
         if not models:
             print("")
             print("---------------------------------------------------------------------------------------")
@@ -63,9 +63,9 @@ class MyApp(MONAILabelApp):
             print(f"    all, {', '.join(configs.keys())}")
             print("---------------------------------------------------------------------------------------")
             print("")
-            exit(-1)
+            # exit(-1)
 
-        models = models.split(",")
+        models = models.split(",") if models else []
         models = [m.strip() for m in models]
         invalid = [m for m in models if m != "all" and not configs.get(m)]
         if invalid:
@@ -90,7 +90,7 @@ class MyApp(MONAILabelApp):
 
         logger.info(f"+++ Using Models: {list(self.models.keys())}")
 
-        self.sam = strtobool(conf.get("sam", "true"))
+        self.sam = strtobool(conf.get("sam2", "true"))
         super().__init__(
             app_dir=app_dir,
             studies=studies,

--- a/sample-apps/radiology/main.py
+++ b/sample-apps/radiology/main.py
@@ -64,7 +64,7 @@ class MyApp(MONAILabelApp):
             print("")
             exit(-1)
 
-        models = models.split(",")
+        models = models.split(",") if models else []
         models = [m.strip() for m in models]
         # Can be configured with --conf scribbles false or true
         self.scribbles = conf.get("scribbles", "true") == "true"
@@ -100,7 +100,7 @@ class MyApp(MONAILabelApp):
         # Load models from bundle config files, local or released in Model-Zoo, e.g., --conf bundles <spleen_ct_segmentation>
         self.bundles = get_bundle_models(app_dir, conf, conf_key="bundles") if conf.get("bundles") else None
 
-        self.sam = strtobool(conf.get("sam", "true"))
+        self.sam = strtobool(conf.get("sam2", "true"))
         super().__init__(
             app_dir=app_dir,
             studies=studies,

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,11 @@ install_requires =
     scikit-learn
     scipy
     google-auth>=2.29.0
+
+[options.extras_require]
+all =
     SAM-2 @ git+https://github.com/facebookresearch/sam2.git@c2ec8e14a185632b0a5d8b161928ceb50197eddc ; python_version >= '3.10'
+    #sam2>=0.4.1; python_version >= '3.10'
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,11 +70,8 @@ install_requires =
     scikit-learn
     scipy
     google-auth>=2.29.0
-
-[options.extras_require]
-all =
-    SAM-2 @ git+https://github.com/facebookresearch/sam2.git@c2ec8e14a185632b0a5d8b161928ceb50197eddc ; python_version >= '3.10'
-    #sam2>=0.4.1; python_version >= '3.10'
+    sam2>=0.4.1; python_version >= '3.10'
+    #SAM-2 @ git+https://github.com/facebookresearch/sam2.git@c2ec8e14a185632b0a5d8b161928ceb50197eddc ; python_version >= '3.10'
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9


### PR DESCRIPTION
Currently SAM2 official package is not available on PyPI.  
And for security reasons required dependencies can be direct URIs.

Need an intermediate solution to push monailabel to PyPI with sam2 dependency which uses SAM2 models.
Add  note for users how they can override dependency package to use SAM2.1 models.