### PR TITLE
Slicer plugin: Keep showing segmentation in 3D when using sam_3d

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1828,7 +1828,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # We remember if closed surface representation was present and restore it after import.
                 segmentationRepresentationNames = []
                 segmentationNode.GetSegmentation().GetContainedRepresentationNames(segmentationRepresentationNames)
-                hasClosedSurfaceRepresentation = slicer.vtkSegmentationConverter.GetSegmentationClosedSurfaceRepresentationName() in segmentationRepresentationNames
+                hasClosedSurfaceRepresentation = (
+                    slicer.vtkSegmentationConverter.GetSegmentationClosedSurfaceRepresentationName()
+                    in segmentationRepresentationNames
+                )
 
                 slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
                     labelmapVolumeNode, segmentationNode, segmentIds

--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1823,9 +1823,20 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     segmentIds.InsertNextValue(label)
 
                 # faster import (based on selected segmentIds)
+
+                # ImportLabelmapToSegmentationNode overwrites segments, which removes all non-source representations.
+                # We remember if closed surface representation was present and restore it after import.
+                segmentationRepresentationNames = []
+                segmentationNode.GetSegmentation().GetContainedRepresentationNames(segmentationRepresentationNames)
+                hasClosedSurfaceRepresentation = slicer.vtkSegmentationConverter.GetSegmentationClosedSurfaceRepresentationName() in segmentationRepresentationNames
+
                 slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
                     labelmapVolumeNode, segmentationNode, segmentIds
                 )
+
+                if hasClosedSurfaceRepresentation:
+                    segmentationNode.CreateClosedSurfaceRepresentation()
+
                 slicer.mrmlScene.RemoveNode(labelmapVolumeNode)
             else:
                 existingCount = segmentation.GetNumberOfSegments()

--- a/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
+++ b/plugins/slicer/MONAILabel/Resources/UI/MONAILabel.ui
@@ -209,8 +209,29 @@
        </widget>
       </item>
       <item row="8" column="0" colspan="2">
-       <widget class="QWidget" name="trainWidget">
+       <widget class="QFrame" name="trainWidget">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
         <layout class="QGridLayout" name="gridLayout_5">
+         <property name="leftMargin">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>3</number>
+         </property>
+         <property name="rightMargin">
+          <number>3</number>
+         </property>
+         <property name="bottomMargin">
+          <number>3</number>
+         </property>
+         <property name="spacing">
+          <number>3</number>
+         </property>
          <item row="1" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
@@ -277,8 +298,8 @@
            </item>
           </layout>
          </item>
-       </layout>
-      </widget>
+        </layout>
+       </widget>
       </item>
       <item row="4" column="1">
        <widget class="QPushButton" name="saveLabelButton">
@@ -540,17 +561,17 @@
             <property name="placeMultipleMarkups">
              <enum>qSlicerMarkupsPlaceWidget::ForcePlaceSingleMarkup</enum>
             </property>
-            <property name="sizePolicy">
+          <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-              </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
         </item>
        </layout>
+      </item>
+     </layout>
       </item>
      </layout>
     </widget>
@@ -714,10 +735,10 @@
              <enum>qSlicerMarkupsPlaceWidget::ForcePlaceSingleMarkup</enum>
             </property>
             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
-              </sizepolicy>
+             </sizepolicy>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
In 3D Slicer, when sam_3d result was imported it always removed the closed surface representation, therefore if a user wanted to see the segmentation in 3D then after each sam_3d update the user had to go to "Segment Editor" section and click "Show 3D".

This commit makes the MONAILabel module remember the "Show 3D" state when performing a sam_3d update.

Another small fix is included: when editing the Slicer module's GUI with Qt Designer then the `trainWidget` always got removed. Fixed it by assigning an appropriate widget class.
