### PR TITLE
Fix server url Slicer client bug

### DIFF
--- a/plugins/slicer/MONAILabel/MONAILabel.py
+++ b/plugins/slicer/MONAILabel/MONAILabel.py
@@ -1059,6 +1059,10 @@ class MONAILabelWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         serverUrl = self.ui.serverComboBox.currentText.strip()
         if not serverUrl:
             serverUrl = "http://127.0.0.1:8000"
+        elif not serverUrl.startswith(("http://", "https://")):
+            serverUrl = "http://" + serverUrl
+        elif serverUrl.startswith(":") or serverUrl.isdigit():
+            serverUrl = "http://0.0.0.0:" + serverUrl.lstrip(":")
         return serverUrl.rstrip("/")
 
     def saveServerUrl(self):


### PR DESCRIPTION
If the input of the lineedit on MONAILabel module of Slicer is "IP:PORT" or ":PORT" the connection to the server fails. This commit solves that problem