### PR TITLE
Add cvat_labels_file conf parameter to support CSV label definitions with attributes

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -45,7 +45,7 @@ jobs:
           rm -rf /opt/hostedtoolcache
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
 
   build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ pydicom-seg==0.4.1
 pynetdicom==2.0.2
 pynrrd==1.0.0
 numpymaxflow==0.0.7
+setuptools>=61
+setuptools-scm<8.0.0
 girder-client==3.2.3
 ninja==1.11.1.1
 einops==0.7.0

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -9,12 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import os
 import csv
 import json
+import logging
+import os
 from datetime import timedelta
-from typing import List, Dict, Union
+from typing import Dict, List, Union
 
 import lib.configs
 import numpy as np

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -11,10 +11,10 @@
 
 import logging
 import os
-from datetime import timedelta
-from typing import List, Dict, Union
 import csv
 import json
+from datetime import timedelta
+from typing import List, Dict, Union
 
 import lib.configs
 import numpy as np

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -12,7 +12,9 @@
 import logging
 import os
 from datetime import timedelta
-from typing import Dict
+from typing import List, Dict, Union
+import csv
+import json
 
 import lib.configs
 import numpy as np

--- a/sample-apps/endoscopy/main.py
+++ b/sample-apps/endoscopy/main.py
@@ -98,11 +98,11 @@ class MyApp(MONAILabelApp):
 
     def read_labels_from_file(self, file_path: str) -> List[Dict[str, Union[str, int, list]]]:
         labels = []
-        
+
         try:
-            with open(file_path, mode='r') as csvfile:
+            with open(file_path) as csvfile:
                 reader = csv.DictReader(csvfile)
-                
+
                 for row in reader:
                     # Check for required fields
                     if "name" in row and "id" in row and "color" in row:
@@ -113,26 +113,26 @@ class MyApp(MONAILabelApp):
                                 attributes = json.loads(row["attributes"].strip())
                             except json.JSONDecodeError as e:
                                 logger.warning(f"Could not parse attributes JSON for row {row}: {e}")
-                        
+
                         entry = {
                             "name": row["name"],
                             "id": int(row["id"]),
                             "color": row["color"],
                             "type": "any",
-                            "attributes": attributes
+                            "attributes": attributes,
                         }
                         labels.append(entry)
                     else:
                         logger.warning(f"Skipping row due to missing fields: {row}")
-                        
+
                 logger.info(f"Loaded {len(labels)} labels from {file_path}")
         except FileNotFoundError:
             logger.error(f"Label file {file_path} not found!")
         except Exception as e:
             logger.error(f"Error reading label file {file_path}: {e}")
-        
+
         return labels
-        
+
     def init_datastore(self) -> Datastore:
         if settings.MONAI_LABEL_DATASTORE_URL and settings.MONAI_LABEL_DATASTORE.lower() == "cvat":
             logger.info(f"Using CVAT: {self.studies}")


### PR DESCRIPTION
This pull request introduces a new configuration parameter, `cvat_labels_file`, which allows users to specify a CSV file containing label definitions along with their attributes. The changes include:

**New Method:**

- Implemented `read_labels_from_file` to parse the CSV file, reading each label and its attributes (provided as a JSON array string) and returning them in the required format.

**Datastore Initialization:**

- Updated the `init_datastore` method to check if `cvat_labels_file` is provided in the configuration.
- If present, the method loads labels using `read_labels_from_file` instead of relying solely on the configuration-provided labels.
- This enhancement enables advanced CVAT features by leveraging detailed label attributes.

These updates aim to improve the flexibility and functionality of MONAILabel in endoscopy applications, making it easier to harness CVAT’s advanced capabilities. Please review and let me know if any further modifications are needed.