### PR TITLE
Add configuration to allow using itk or pydicom_seg for DICOM SEG

### DIFF
--- a/monailabel/config.py
+++ b/monailabel/config.py
@@ -115,6 +115,8 @@ class Settings(BaseSettings):
         else "https://huggingface.co/facebook/sam2-hiera-large/resolve/main/sam2_hiera_l.yaml"
     )
 
+    MONAI_LABEL_USE_ITK_FOR_DICOM_SEG: bool = os.environ.get("MONAI_LABEL_USE_ITK_FOR_DICOM_SEG", True)
+
     model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=True,

--- a/monailabel/datastore/utils/convert.py
+++ b/monailabel/datastore/utils/convert.py
@@ -23,6 +23,7 @@ import SimpleITK
 from monai.transforms import LoadImage
 from pydicom.filereader import dcmread
 
+from monailabel.config import settings
 from monailabel.datastore.utils.colors import GENERIC_ANATOMY_COLORS
 from monailabel.transform.writer import write_itk
 from monailabel.utils.others.generic import run_command
@@ -80,7 +81,12 @@ def binary_to_image(reference_image, label, dtype=np.uint8, file_ext=".nii.gz"):
     return output_file
 
 
-def nifti_to_dicom_seg(series_dir, label, label_info, file_ext="*", use_itk=True) -> str:
+def nifti_to_dicom_seg(series_dir, label, label_info, file_ext="*", use_itk=None) -> str:
+
+    # Only use config if no explicit override
+    if use_itk is None:
+        use_itk = settings.MONAI_LABEL_USE_ITK_FOR_DICOM_SEG
+
     start = time.time()
 
     label_np, meta_dict = LoadImage(image_only=False)(label)

--- a/monailabel/endpoints/infer.py
+++ b/monailabel/endpoints/infer.py
@@ -183,7 +183,7 @@ def run_inference(
         suffixes = [".nii", ".nii.gz", ".nrrd"]
         image_path = [image_uri.replace(suffix, "") for suffix in suffixes if image_uri.endswith(suffix)][0]
         res_img = result.get("file") if result.get("file") else result.get("label")
-        dicom_seg_file = nifti_to_dicom_seg(image_path, res_img, p.get("label_info"), use_itk=True)
+        dicom_seg_file = nifti_to_dicom_seg(image_path, res_img, p.get("label_info"))
         result["dicom_seg"] = dicom_seg_file
 
     return send_response(instance.datastore(), result, output, background_tasks)


### PR DESCRIPTION
## Motivation and Context

When working with DICOM images and running inferences to generate DICOM Segs, the ITK tool (`itkimage2segimage`) can sometimes fail: even if MONAILabel successfully produces a segmentation, converting it to a DICOM Seg may abort if a required tag is missing, as shown next, which aborts all the process and in the end no segmentation is returned.

`E: CodingSchemeDesignator (0008,0102) absent in CodeSequenceMacro (type 1)
E: Could not write item #0 in ProcedureCodeSequence: Invalid Value
FATAL ERROR: Writing of the SEG dataset failed! Error: Invalid Value. Please report the problem to the developers, ideally accompanied by a de-identified dataset allowing to reproduce the problem!
ERROR: Conversion failed.
`

To solve this error, a fix is presented here (https://qiicr.gitbook.io/dcmqi-guide/faq#conversion-fails-with-the-missing-attribute-s-error-what-should-i-do), but this is not optimal when dealing with real DICOM data, where files are constantly incoming to the PACS, since it requires to modify the attribute in all dicom files.

Since MONAILabel already supports `pydicom_seg` for DICOM SEG generation, this PR introduces a way to switch between the `itkimage2segimage` tool and `pydicom_seg`, which was previously hardcoded and could not be changed unless we changed the code.

## Summary

- Add `MONAI_LABEL_USE_ITK_FOR_DICOM_SEG` in `monailabel/config.py`, overridable via environment variable. Default is True to preserve existing behavior.
- Update `nifti_to_dicom_seg` in `monailabel/datastore/utils/convert.py` to respect this setting. The function can still override the config if needed; the setting only applies when use_itk is None.

## Test Plan

- Verify that infer requests and save label endpoints work correctly across different datastores.