### PR TITLE
Assign distinct colors to DICOM SEG segments (ITK export path)

### DIFF
--- a/monailabel/datastore/utils/colors.py
+++ b/monailabel/datastore/utils/colors.py
@@ -321,3 +321,43 @@ GENERIC_ANATOMY_COLORS = {
     "unknown": (100, 100, 130),
     "cyst": (205, 205, 100),
 }
+
+# Key of the black background entry, excluded from the fallback palette so that a
+# segment never resolves to an invisible (0, 0, 0) color.
+_BACKGROUND_KEY = "background"
+
+# Number of channels in an RGB color triple.
+_RGB_CHANNELS = 3
+
+# Distinct, non-background colors used to give segments without a known anatomy
+# name (and without an explicit color) different colors instead of all defaulting
+# to red. See issue #1751.
+_FALLBACK_COLORS = [color for name, color in GENERIC_ANATOMY_COLORS.items() if name != _BACKGROUND_KEY]
+
+
+def get_segment_color(name, info=None, index=0):
+    """Return an ``[r, g, b]`` display color for a DICOM SEG segment.
+
+    Resolution order:
+
+    1. an explicit ``color`` provided in ``info`` (from the label metadata);
+    2. the palette entry whose key matches ``name`` in ``GENERIC_ANATOMY_COLORS``;
+    3. a palette color chosen by ``index`` so that consecutive segments without a
+       known anatomy name receive *distinct* colors instead of all defaulting to
+       red (see issue #1751).
+
+    Args:
+        name: Segment label used to look up a known anatomy color.
+        info: Optional segment metadata; an explicit ``color`` takes precedence.
+        index: Position of the segment, used to pick a distinct fallback color.
+
+    Returns:
+        A list of three ``int`` RGB channel values.
+    """
+    info = info or {}
+    color = info.get("color")
+    if color:
+        return [int(c) for c in list(color)[:_RGB_CHANNELS]]
+    if name in GENERIC_ANATOMY_COLORS:
+        return [int(c) for c in GENERIC_ANATOMY_COLORS[name][:_RGB_CHANNELS]]
+    return [int(c) for c in _FALLBACK_COLORS[index % len(_FALLBACK_COLORS)][:_RGB_CHANNELS]]

--- a/monailabel/datastore/utils/colors.py
+++ b/monailabel/datastore/utils/colors.py
@@ -332,7 +332,9 @@ _RGB_CHANNELS = 3
 # Distinct, non-background colors used to give segments without a known anatomy
 # name (and without an explicit color) different colors instead of all defaulting
 # to red. See issue #1751.
-_FALLBACK_COLORS = [color for name, color in GENERIC_ANATOMY_COLORS.items() if name != _BACKGROUND_KEY]
+_FALLBACK_COLORS = list(
+    dict.fromkeys(color for name, color in GENERIC_ANATOMY_COLORS.items() if name != _BACKGROUND_KEY)
+)
 
 
 def get_segment_color(name, info=None, index=0):

--- a/monailabel/datastore/utils/convert.py
+++ b/monailabel/datastore/utils/convert.py
@@ -35,7 +35,7 @@ except ImportError:
 
 from monailabel import __version__
 from monailabel.config import settings
-from monailabel.datastore.utils.colors import GENERIC_ANATOMY_COLORS
+from monailabel.datastore.utils.colors import get_segment_color
 from monailabel.transform.writer import write_itk
 
 logger = logging.getLogger(__name__)
@@ -434,9 +434,10 @@ def _itk_nifti_to_dicom_seg(series_dir, label, label_info) -> str:
             # Use custom attribute as-is
             segment_descriptions.append(segment_attr)
         else:
-            # Build default template for ITK method
-            rgb = list(info.get("color", GENERIC_ANATOMY_COLORS.get(name, (255, 0, 0))))[0:3]
-            rgb = [int(x) for x in rgb]
+            # Build default template for ITK method. Segments without an explicit
+            # color or a known anatomy name get a distinct fallback color (keyed on
+            # their index) instead of all defaulting to red (see issue #1751).
+            rgb = get_segment_color(name, info, i)
 
             segment_attr = {
                 "labelID": int(label_id),

--- a/tests/unit/datastore/test_colors.py
+++ b/tests/unit/datastore/test_colors.py
@@ -1,0 +1,51 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from monailabel.datastore.utils.colors import GENERIC_ANATOMY_COLORS, get_segment_color
+
+# Number of unnamed segments used to check that fallback colors are distinct.
+_UNNAMED_SEGMENTS = 5
+# The color every unnamed segment used to collapse to before the fix (issue #1751).
+_LEGACY_RED = [255, 0, 0]
+# Black background color that must never be assigned to a segment.
+_BLACK = [0, 0, 0]
+
+
+class TestGetSegmentColor(unittest.TestCase):
+    def test_explicit_color_takes_precedence(self):
+        self.assertEqual(get_segment_color("anything", {"color": [10, 20, 30]}, 0), [10, 20, 30])
+
+    def test_explicit_color_is_truncated_to_rgb(self):
+        # An RGBA (or longer) color is reduced to its first three channels.
+        self.assertEqual(get_segment_color("anything", {"color": [10, 20, 30, 255]}, 0), [10, 20, 30])
+
+    def test_known_anatomy_name_uses_palette(self):
+        self.assertEqual(get_segment_color("bone"), list(GENERIC_ANATOMY_COLORS["bone"]))
+
+    def test_unnamed_segments_get_distinct_colors(self):
+        # Regression for #1751: segments without an explicit color and without a
+        # known anatomy name previously all fell back to red, so a multi-segment
+        # DICOM SEG showed up entirely red. They must now be distinct.
+        colors = [get_segment_color(f"Segment_{i}", {}, i) for i in range(_UNNAMED_SEGMENTS)]
+        distinct = {tuple(color) for color in colors}
+        self.assertEqual(len(distinct), _UNNAMED_SEGMENTS)
+        self.assertNotIn(_LEGACY_RED, colors)
+
+    def test_background_is_never_selected(self):
+        # The black background entry must never be handed to a real segment.
+        for i in range(len(GENERIC_ANATOMY_COLORS)):
+            self.assertNotEqual(get_segment_color("no-such-name", {}, i), _BLACK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datastore/test_colors.py
+++ b/tests/unit/datastore/test_colors.py
@@ -13,8 +13,9 @@ import unittest
 
 from monailabel.datastore.utils.colors import GENERIC_ANATOMY_COLORS, get_segment_color
 
-# Number of unnamed segments used to check that fallback colors are distinct.
-_UNNAMED_SEGMENTS = 5
+# Number of unnamed segments needed to cover the fallback palette's first
+# duplicate RGB value, which previously appeared at indices 4 and 16.
+_UNNAMED_SEGMENTS = 17
 # The color every unnamed segment used to collapse to before the fix (issue #1751).
 _LEGACY_RED = [255, 0, 0]
 # Black background color that must never be assigned to a segment.


### PR DESCRIPTION
## Summary

Fixes #1751 — DICOM SEG shows all segments as the same color (red).

The ITK/dcmqi export path used the same red fallback whenever a segment had no explicit color and its name was absent from `GENERIC_ANATOMY_COLORS`.

## Change

- Add `get_segment_color(name, info, index)` with the existing priority: explicit color, known anatomy color, then an indexed fallback palette color.
- Exclude the black background entry and deduplicate repeated RGB tuples while preserving palette order.
- Use the helper in `_itk_nifti_to_dicom_seg` and cover the first prior duplicate span with 17 unknown segments.

Behavior for explicit colors and known anatomy names is unchanged. The default highdicom path is unaffected.

## Test verification (RED → GREEN)

**RED** — before palette deduplication, the 17-segment regression failed:

```text
AssertionError: 16 != 17
1 failed, 4 passed
```

**GREEN** — after deduplication:

```text
5 passed
monailabel/datastore/utils/colors.py: 100% coverage
```

All repository pre-commit hooks pass locally from a clean isolated cache on Python 3.12. The remote pre-commit.ci run is currently blocked by the pinned `pyupgrade` hook crashing inside pre-commit.ci's Python 3.14 environment (`TypeError: cannot use a bytes pattern on a string-like object`); black, flake8, mypy, and every other remote hook pass.

The full local unit replay is iso-baseline: upstream and this branch both stop during collection on the same pre-existing `girder_client` / `pkg_resources` dependency incompatibility; this branch collects five additional tests before that identical failure.
